### PR TITLE
[fix] A4出力を維持するための印刷スタイル調整

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -684,13 +684,16 @@ body::before {
 }
 
 /* === 印刷用スタイル === */
-@media print {
-  /* ページ設定 */
-  @page {
-    size: A4;
-    margin: 0;
-  }
+/*
+  Chrome など一部ブラウザでは @page を @media print の内側に記述すると size 指定が無視される。
+  PDF 生成時に A4 からはみ出さないよう、トップレベルで宣言する。
+*/
+@page {
+  size: A4;
+  margin: 0;
+}
 
+@media print {
   /* htmlとbodyの余白を明示的に制御 */
   html {
     margin: 0;


### PR DESCRIPTION
## 背景
- PDF への出力時に A4 からはみ出してしまう事象が報告されました。
- Chrome など一部ブラウザでは `@page` を `@media print` の内側に記述すると `size` 指定が無視されるケースがあり、ページサイズが反映されないことが原因でした。

## 対応内容
- `@page` ルールをトップレベルへ移動し、常に A4 サイズと余白設定が適用されるよう修正しました。
- コメントを追加し、ブラウザ依存の挙動と対応理由を明示しました。

## テスト
- npm run test:layout


------
https://chatgpt.com/codex/tasks/task_e_6909e951c3a4832681ba2cab870ab8b7