### PR TITLE
[feat] フレーズ練習の多様化とレイアウト改善

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -988,27 +988,40 @@ body::before {
   padding: 0;
 }
 
+.a4-preview-page .phrase-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4mm 5mm;
+}
+
 .a4-preview-page .phrase-item {
-  margin-bottom: 2mm;
+  margin-bottom: 0;
   page-break-inside: avoid;
 }
 
 .a4-preview-page .phrase-header {
-  margin-bottom: 1mm;
+  margin-bottom: 0;
 }
 
 .a4-preview-page .phrase-english {
-  font-size: 13pt;
+  font-size: 12pt;
 }
 
 .a4-preview-page .phrase-japanese {
-  font-size: 10pt;
+  font-size: 9.5pt;
+}
+
+.a4-preview-page .phrase-usage {
+  font-size: 7.5pt;
+}
+
+.a4-preview-page .phrase-focus-words {
+  font-size: 7.5pt;
 }
 
 .a4-preview-page .phrase-situation {
   font-size: 8pt;
   background: none;
-  border: 1px solid #ddd;
+  border: 1px solid #cbd5f5;
 }
 
 /* プレビューでのベースライン色調整 */
@@ -1059,6 +1072,10 @@ body::before {
   .note-page {
     transform: scale(0.8);
     transform-origin: top center;
+  }
+
+  .phrase-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1128,11 +1145,25 @@ body::before {
 
 /* フレーズ練習 */
 .phrase-practice {
-  padding: 0mm 0;
+  padding: 0;
+}
+
+.practice-title--phrase {
+  margin-bottom: 5mm;
+}
+
+.phrase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(85mm, 1fr));
+  gap: 4mm 6mm;
 }
 
 .phrase-item {
-  margin-bottom: 2mm;
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2mm;
+  page-break-inside: avoid;
 }
 
 /* フレーズヘッダー部分 */
@@ -1140,8 +1171,7 @@ body::before {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 6mm;
-  margin-bottom: 1mm;
+  gap: 4mm;
 }
 
 .phrase-main {
@@ -1149,34 +1179,113 @@ body::before {
 }
 
 .phrase-english {
-  font-size: 13pt;
-  font-weight: bold;
+  font-size: 12pt;
+  font-weight: 600;
   color: var(--text-color);
-  line-height: 1.2;
+  line-height: 1.25;
 }
 
 .phrase-japanese {
-  font-size: 10pt;
-  color: #666;
-  margin-top: 1mm;
-  line-height: 1.1;
+  font-size: 9.5pt;
+  color: #606f7b;
+  margin-top: 0.5mm;
+  line-height: 1.2;
 }
 
 /* 使用場面 - 右側に配置 */
 .phrase-situation {
   font-size: 8pt;
-  color: #999;
-  background: #f8f8f8;
+  color: #64748b;
+  background: #f8fafc;
   padding: 1px 4px;
-  border-radius: 2px;
+  border-radius: 4px;
   white-space: nowrap;
   align-self: flex-start;
   flex-shrink: 0;
+  border: 1px solid #e2e8f0;
+}
+
+.phrase-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2mm 4mm;
+  align-items: center;
+}
+
+.phrase-usage {
+  font-size: 8pt;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  letter-spacing: 0.04em;
+}
+
+.phrase-usage.usage-core {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.phrase-usage.usage-common {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.phrase-usage.usage-situational {
+  background: #fef9c3;
+  color: #b45309;
+}
+
+.phrase-usage.usage-critical {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.phrase-usage.usage-specialized {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.phrase-focus-words {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2mm;
+  align-items: center;
+  font-size: 8pt;
+  color: #475569;
+}
+
+.phrase-focus-label {
+  font-weight: 600;
+  color: #334155;
+  margin-right: 1mm;
+}
+
+.phrase-focus-token {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #1f2937;
+  border: 1px solid #e2e8f0;
 }
 
 /* 練習用罫線部分 */
 .phrase-lines {
-  margin-top: 0mm;
+  margin-top: 0;
+}
+
+.phrase-item .line-separator-small {
+  --line-separator-small-height: 3mm;
+}
+
+.phrase-empty {
+  text-align: center;
+  font-size: 10pt;
+  color: #64748b;
+  margin: 8mm 0;
 }
 
 /* 練習モード共通のタイトル */

--- a/test/content-test.js
+++ b/test/content-test.js
@@ -128,11 +128,25 @@ test('単語データの構造', wordStructureRegex.test(allContent), '単語デ
 // 5. フレーズデータの構造チェック
 console.log('\n💬 フレーズデータ構造のチェック');
 const phraseStructureRegex =
-  /{\s*english:\s*["'][^"']+["'],\s*japanese:\s*["'][^"']+["'],\s*situation:\s*["'][^"']+["']\s*}/;
+  /english:\s*["'][^"']+["'][\s\S]*?japanese:\s*["'][^"']+["'][\s\S]*?situation:\s*["'][^"']+["']/;
 test(
   'フレーズデータの構造',
   phraseStructureRegex.test(allContent),
   'フレーズデータの構造が正しくありません'
+);
+
+const phraseMetadataRegex = /\busageFrequency\b/;
+test(
+  'フレーズデータに使用頻度メタデータが含まれる',
+  phraseMetadataRegex.test(phraseDataContent),
+  'usageFrequency メタデータが追加されていません'
+);
+
+const phraseFocusMetadataRegex = /\bfocusWords\b/;
+test(
+  'フレーズデータに覚えたい単語メタデータが含まれる',
+  phraseFocusMetadataRegex.test(phraseDataContent),
+  'focusWords メタデータが追加されていません'
 );
 
 // 6. 例文データの構造チェック


### PR DESCRIPTION
## 背景
- フレーズ練習モードが4問固定のままで、同じ構造の文章が並びやすく学習バランスに課題があった
- 「よく使う表現」や「覚えたい単語」を意識した出題調整ができていなかった
- 問題数を3倍程度に増やすためのレイアウト最適化も必要だった

## 変更内容
- フレーズデータに使用頻度・重点語彙・パターン推定を付与するユーティリティを追加
- フレーズ練習生成ロジックを拡張し、12問をメタデータに基づいて多様な構成で抽出・表示
- 焦点語彙や使用頻度バッジを表示する新しいUIと、2カラムに収まる印刷レイアウトを整備
- コンテンツ検証スクリプトに新しいメタデータ存在チェックを追加

## テスト
- npm run test:content
- npm run test:layout
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690a783ee53883268c6b2b767b62ae1f