### PR TITLE
[fix] 印刷ノートのページ番号を削除

### DIFF
--- a/script.js
+++ b/script.js
@@ -376,17 +376,6 @@ function generateNotePage(pageNumber, totalPages) {
     html += generateNormalPractice(showExamples, showTranslation, ageGroup);
   }
 
-  // ページ番号（複数ページの場合のみ表示）
-  if (totalPages > 1) {
-    html += `
-            <div class="page-number">
-                <span class="page-number-current">${pageNumber}</span>
-                <span class="page-number-separator">/</span>
-                <span class="page-number-total">${totalPages}</span>
-            </div>
-        `;
-  }
-
   html += '</div>';
 
   return html;

--- a/src/services/NoteGeneratorService.ts
+++ b/src/services/NoteGeneratorService.ts
@@ -122,11 +122,6 @@ export class NoteGeneratorService {
           break;
       }
 
-      // Page number for multi-page documents
-      if (state.pageCount > 1) {
-        html += this.generatePageNumber(pageNumber, state.pageCount);
-      }
-
       html += '</div>';
       return html;
     } catch (error) {
@@ -408,19 +403,6 @@ export class NoteGeneratorService {
         <div class="page-separator-line"></div>
       </div>
       <div style="page-break-before: always;"></div>
-    `;
-  }
-
-  /**
-   * Generate page number indicator
-   */
-  private generatePageNumber(current: number, total: number): string {
-    return `
-      <div class="page-number">
-        <span class="page-number-current">${current}</span>
-        <span class="page-number-separator">/</span>
-        <span class="page-number-total">${total}</span>
-      </div>
     `;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -799,31 +799,6 @@ body::before {
     font-size: 8pt !important;
   }
 
-  /* 印刷時のページ番号スタイル調整 */
-  .page-number {
-    background: none !important;
-    box-shadow: none !important;
-    border: none !important;
-    padding: 2mm 4mm !important;
-    font-size: 10pt !important;
-  }
-
-  .page-number-current {
-    font-size: 12pt !important;
-    color: #000 !important;
-    font-weight: bold !important;
-  }
-
-  .page-number-separator {
-    color: #333 !important;
-    font-size: 10pt !important;
-  }
-
-  .page-number-total {
-    color: #333 !important;
-    font-size: 10pt !important;
-  }
-
   /* 複数ページの影を削除 */
   .note-page:not(:first-child) {
     margin-top: 0 !important;
@@ -1322,36 +1297,6 @@ body::before {
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 1px;
-}
-
-/* ページ番号 */
-.page-number {
-  position: absolute;
-  bottom: 10mm;
-  right: 15mm;
-  padding: 5px 10px;
-  background: #f0f0f0;
-  border-radius: 15px;
-  font-size: 12pt;
-  color: #666;
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.page-number-current {
-  font-weight: bold;
-  color: var(--primary-color);
-  font-size: 14pt;
-}
-
-.page-number-separator {
-  color: #999;
-}
-
-.page-number-total {
-  color: #666;
 }
 
 /* 複数ページの場合、各ページに影をつける */

--- a/test/services/NoteGeneratorService.test.ts
+++ b/test/services/NoteGeneratorService.test.ts
@@ -339,14 +339,12 @@ describe('NoteGeneratorService', () => {
       expect(result.html).not.toContain('&amp;lt;');
     });
 
-    it('should include page numbers for multi-page documents', async () => {
+    it('should not render page numbers even for multi-page documents', async () => {
       const state = createMockUIState({ pageCount: 3 });
 
       const result = await service.generateNote(state);
 
-      expect(result.html).toContain('page-number');
-      expect(result.html).toContain('1');
-      expect(result.html).toContain('3');
+      expect(result.html).not.toContain('page-number');
     });
   });
 


### PR DESCRIPTION
## 背景
- PDFに出力した際、右下に表示していたページ番号が潰れて判読できない問題が発生していた
- ページ番号には大きな意味がないため、UIから削除する方針とした

## 変更内容
- ブラウザ版のノート生成処理からページ番号ブロックを除去
- サービスレイヤーのHTML生成ロジックからページ番号生成処理を削除
- ページ番号用のCSSスタイル定義をすべて削除
- マルチページ時のページ番号存在を確認するテストを、ページ番号が出力されないことを確認する内容へ変更

## テスト
- `npm test`
- `npm run test:content`
- `npm run test:layout`


------
https://chatgpt.com/codex/tasks/task_e_690a7fd16f208326ae698381088d4d70