### PR TITLE
[fix] フレーズ練習の印刷レイアウトを単一列に戻す

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -989,7 +989,7 @@ body::before {
 }
 
 .a4-preview-page .phrase-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 4mm 5mm;
 }
 
@@ -1154,7 +1154,7 @@ body::before {
 
 .phrase-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(85mm, 1fr));
+  grid-template-columns: 1fr;
   gap: 4mm 6mm;
 }
 


### PR DESCRIPTION
## 背景
- 直近のスタイル調整によりフレーズ練習の出力が2カラム化し、A4ページに収まりきらない問題が発生していました。

## 対応内容
- `styles.css` の `.phrase-grid` を単一カラム指定に変更し、印刷プレビューでも同じ設定になるよう調整しました。

## 確認内容
- `npm run test:layout`
- `npm run test:content`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_690a8057e4a8832696c8b5dc2337f5cb