### PR TITLE
feat(cloze): add fill-in-the-blank phrase practice mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
               <option value="sentence">文章練習</option>
               <option value="word">単語練習</option>
               <option value="alphabet">アルファベット練習</option>
+              <option value="cloze">穴埋めフレーズ練習</option>
             </select>
           </label>
         </div>
@@ -152,6 +153,45 @@
           </label>
           <button
             id="shufflePhrases"
+            class="btn btn--secondary"
+            style="margin-top: 0.5rem"
+            type="button"
+          >
+            🔄 別のフレーズを表示
+          </button>
+        </div>
+
+        <div class="controls__group" id="clozeOptions" style="display: none">
+          <label class="controls__label">
+            フレーズカテゴリー:
+            <select id="clozeCategory" class="controls__select">
+              <option value="greetings">あいさつ</option>
+              <option value="self_introduction">自己紹介</option>
+              <option value="school">学校生活</option>
+              <option value="shopping">買い物</option>
+              <option value="travel">旅行・移動</option>
+              <option value="feelings">感情表現</option>
+              <option value="daily_life">日常生活</option>
+              <option value="classroom_english">教室での英語</option>
+              <option value="friend_making">友達作り</option>
+              <option value="cultural_exchange">文化交流</option>
+              <option value="emergency_situations">緊急時の表現</option>
+              <option value="numbers_math">数と算数</option>
+            </select>
+          </label>
+          <label class="controls__label">
+            穴埋めタイプ:
+            <select id="clozeBlankType" class="controls__select">
+              <option value="word">単語レベル（単語を空欄に）</option>
+              <option value="char">文字レベル（文字を空欄に）</option>
+            </select>
+          </label>
+          <label class="controls__label">
+            <input type="checkbox" id="showClozeAnswers" class="controls__checkbox" />
+            解答を表示
+          </label>
+          <button
+            id="shuffleCloze"
             class="btn btn--secondary"
             style="margin-top: 0.5rem"
             type="button"

--- a/script.js
+++ b/script.js
@@ -5,12 +5,16 @@ let EXAMPLE_SENTENCES_BY_AGE = {};
 let WORD_LISTS = {};
 let ALPHABET_DATA = {};
 let PHRASE_DATA = {};
+let SIGHT_WORDS_DATA = [];
+let SIGHT_WORD_SET_DATA = new Set();
+let SIGHT_WORD_MAP_DATA = new Map();
 
 let currentExamples = [];
 
 let currentExamplesMeta = { key: '', perPageCount: 0, pageCount: 0 };
 let wordSequenceCache = { key: '', perPage: 0, pageCount: 0, sequence: [] };
 let phraseSequenceCache = { key: '', perPage: 0, pageCount: 0, fingerprint: '', sequence: [] };
+let clozeSequenceCache = { key: '', perPage: 0, pageCount: 0, fingerprint: '', sequence: [] };
 
 const PX_TO_MM = 0.2645833333;
 const A4_HEIGHT_MM = 297;
@@ -24,19 +28,29 @@ let setCurrentExamplesImpl = (examples) => {
 let setCurrentExampleIndicesImpl = () => {};
 
 const modulesReady = (async () => {
-  const [exampleModule, wordModule, alphabetModule, phraseModule, appConfigModule] =
-    await Promise.all([
-      import('./src/data/example-sentences.js'),
-      import('./src/data/word-lists.js'),
-      import('./src/data/alphabet-data.js'),
-      import('./src/data/phrase-data.js'),
-      import('./src/models/app-config.js'),
-    ]);
+  const [
+    exampleModule,
+    wordModule,
+    alphabetModule,
+    phraseModule,
+    appConfigModule,
+    sightWordsModule,
+  ] = await Promise.all([
+    import('./src/data/example-sentences.js'),
+    import('./src/data/word-lists.js'),
+    import('./src/data/alphabet-data.js'),
+    import('./src/data/phrase-data.js'),
+    import('./src/models/app-config.js'),
+    import('./src/data/sight-words.js'),
+  ]);
 
   EXAMPLE_SENTENCES_BY_AGE = exampleModule.EXAMPLE_SENTENCES_BY_AGE;
   WORD_LISTS = wordModule.WORD_LISTS;
   ALPHABET_DATA = alphabetModule.ALPHABET_DATA;
   PHRASE_DATA = phraseModule.PHRASE_DATA;
+  SIGHT_WORDS_DATA = sightWordsModule.SIGHT_WORDS;
+  SIGHT_WORD_SET_DATA = sightWordsModule.SIGHT_WORD_SET;
+  SIGHT_WORD_MAP_DATA = sightWordsModule.SIGHT_WORD_MAP;
 
   currentExamples = Array.isArray(appConfigModule.currentExamples)
     ? appConfigModule.currentExamples
@@ -75,6 +89,10 @@ function resetWordCache() {
 
 function resetPhraseCache() {
   phraseSequenceCache = { key: '', perPage: 0, pageCount: 0, fingerprint: '', sequence: [] };
+}
+
+function resetClozeCache() {
+  clozeSequenceCache = { key: '', perPage: 0, pageCount: 0, fingerprint: '', sequence: [] };
 }
 
 function reportInitializationFailure(error) {
@@ -147,6 +165,7 @@ const OPTION_SECTION_IDS = [
   'customExampleOptions',
   'alphabetOptions',
   'phraseOptions',
+  'clozeOptions',
 ];
 
 const PRACTICE_MODE_CONFIGS = {
@@ -165,6 +184,10 @@ const PRACTICE_MODE_CONFIGS = {
   phrase: {
     sections: ['ageOptions', 'phraseOptions', 'translationOptions'],
     checkboxes: { showExamples: false, showTranslation: true },
+  },
+  cloze: {
+    sections: ['ageOptions', 'clozeOptions'],
+    checkboxes: { showExamples: false, showTranslation: false },
   },
   default: {
     sections: [],
@@ -212,6 +235,10 @@ function setupEventListeners() {
     showSituation: document.getElementById('showSituation'),
     shufflePhrasesBtn: document.getElementById('shufflePhrases'),
     previewBtn: document.getElementById('previewBtn'),
+    clozeCategory: document.getElementById('clozeCategory'),
+    clozeBlankType: document.getElementById('clozeBlankType'),
+    showClozeAnswers: document.getElementById('showClozeAnswers'),
+    shuffleClozeBtn: document.getElementById('shuffleCloze'),
   };
 
   addEventListenerIfExists(elements.showExamples, 'change', updatePreview);
@@ -282,6 +309,17 @@ function setupEventListeners() {
     updatePreview();
   });
 
+  addEventListenerIfExists(elements.clozeCategory, 'change', () => {
+    resetClozeCache();
+    updatePreview();
+  });
+  addEventListenerIfExists(elements.clozeBlankType, 'change', updatePreview);
+  addEventListenerIfExists(elements.showClozeAnswers, 'change', updatePreview);
+  addEventListenerIfExists(elements.shuffleClozeBtn, 'click', () => {
+    resetClozeCache();
+    updatePreview();
+  });
+
   addEventListenerIfExists(elements.printBtn, 'click', printNote);
 
   if (elements.previewBtn) {
@@ -297,6 +335,7 @@ function setupEventListeners() {
     updateOptionsVisibility();
     resetWordCache();
     resetPhraseCache();
+    resetClozeCache();
     setCurrentExamples([]);
     updatePreview();
   });
@@ -516,6 +555,7 @@ function calculateBaseLayout(state) {
     sentence: calculateSentencePracticeLayout(state.lineHeight, state.showTranslation),
     word: calculateWordPracticeLayout(state.lineHeight),
     phrase: calculatePhrasePracticeLayout(state.lineHeight),
+    cloze: calculateClozePracticeLayout(state.lineHeight),
   };
 }
 
@@ -637,6 +677,12 @@ function updateAutoLayoutNotice(result, state, baseLayout) {
   notice.dataset.status = 'idle';
 }
 
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
 function clampNumber(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -739,6 +785,8 @@ function generateNotePage(pageNumber, totalPages, layoutOverrides = {}) {
       ageGroup,
       layoutOverrides.phrase
     );
+  } else if (practiceMode === 'cloze') {
+    html += generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverrides.cloze);
   } else {
     html += generateNormalPractice(
       pageNumber,
@@ -1831,6 +1879,256 @@ function ensurePhraseSequence(category, ageGroup, perPage, pageCount, phrases) {
   }
 
   return phraseSequenceCache.sequence;
+}
+
+// === 穴埋めフレーズ練習（Cloze Practice） ===
+
+function calculateClozePracticeLayout(lineHeight) {
+  const basePhrases = getClozeCapacity(lineHeight);
+  const minPhrases = Math.max(1, Math.min(basePhrases - 1, Math.floor(basePhrases * 0.7)));
+
+  return {
+    property: 'clozesPerPage',
+    label: '穴埋め数',
+    baseValue: basePhrases,
+    minValue: minPhrases,
+  };
+}
+
+function getClozeCapacity(lineHeight) {
+  const availableHeight = 277;
+  const itemHeight = 20 + 2 * lineHeight;
+  const maxItems = Math.max(1, Math.floor(availableHeight / itemHeight));
+  const safetyFactor = lineHeight >= 12 ? 0.5 : 0.55;
+  const safeItems = Math.max(1, Math.floor(maxItems * safetyFactor));
+  return Math.min(4, Math.max(2, safeItems));
+}
+
+function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride = {}) {
+  let html = '<div class="cloze-practice">';
+  const clozeCategoryElement = document.getElementById('clozeCategory');
+  const clozeCategory = (clozeCategoryElement && clozeCategoryElement.value) || 'greetings';
+  const blankTypeElement = document.getElementById('clozeBlankType');
+  const blankType = (blankTypeElement && blankTypeElement.value) || 'word';
+  const showAnswers = Boolean(document.getElementById('showClozeAnswers')?.checked);
+  const lineHeight = parseInt(document.getElementById('lineHeight').value);
+
+  let allPhrases;
+  if (PHRASE_DATA[clozeCategory]) {
+    if (PHRASE_DATA[clozeCategory][ageGroup]) {
+      allPhrases = PHRASE_DATA[clozeCategory][ageGroup];
+    } else {
+      const availableAges = Object.keys(PHRASE_DATA[clozeCategory]);
+      const fallbackAge = availableAges.includes('7-9') ? '7-9' : availableAges[0];
+      allPhrases = PHRASE_DATA[clozeCategory][fallbackAge] || [];
+    }
+  } else {
+    allPhrases = PHRASE_DATA.greetings?.[ageGroup] || PHRASE_DATA.greetings?.['7-9'] || [];
+  }
+
+  const safePhrases = Array.isArray(allPhrases) ? allPhrases : [];
+
+  if (!safePhrases.length) {
+    return `
+      <div class="cloze-practice">
+        <p class="phrase-empty">このカテゴリーには現在表示できるフレーズがありません。</p>
+      </div>
+    `;
+  }
+
+  const layoutInfo = calculateClozePracticeLayout(lineHeight);
+  const clozesPerPage = resolveLayoutValue(layoutInfo, layoutOverride?.clozesPerPage);
+  const pageCount = Math.max(1, totalPages || 1);
+  const phrases = ensureClozeSequence(
+    clozeCategory,
+    ageGroup,
+    clozesPerPage,
+    pageCount,
+    safePhrases
+  );
+
+  const startIndex = (pageNumber - 1) * clozesPerPage;
+  const pagePhrases = phrases.slice(startIndex, startIndex + clozesPerPage).filter(Boolean);
+
+  if (!pagePhrases.length) {
+    html +=
+      '<p class="phrase-empty">このページに表示できるフレーズが不足しています。条件を変更してください。</p>';
+    html += '</div>';
+    return html;
+  }
+
+  const categoryNames = {
+    greetings: 'あいさつ',
+    self_introduction: '自己紹介',
+    school: '学校生活',
+    shopping: '買い物',
+    travel: '旅行・移動',
+    feelings: '感情表現',
+    daily_life: '日常生活',
+    classroom_english: '教室での英語',
+    friend_making: '友達作り',
+    cultural_exchange: '文化交流',
+    emergency_situations: '緊急時の表現',
+    numbers_math: '数と算数',
+  };
+
+  const blankTypeLabel = blankType === 'char' ? '文字レベル' : '単語レベル';
+  const pageLabel = pageCount > 1 ? ` (${pageNumber}/${pageCount})` : '';
+  html += `<h3 class="practice-title practice-title--cloze">Fill in the Blanks - ${categoryNames[clozeCategory] || clozeCategory}${pageLabel}</h3>`;
+  html += `<p class="cloze-type-label">${blankTypeLabel}</p>`;
+  html += '<div class="cloze-grid">';
+
+  const clozeResults = pagePhrases.map((p) => generateClozeText(p.english, blankType));
+
+  for (let i = 0; i < pagePhrases.length; i++) {
+    const phrase = pagePhrases[i];
+    const clozeResult = clozeResults[i];
+    html += `
+      <div class="cloze-item">
+        <div class="cloze-header">
+          <div class="cloze-main">
+            <div class="cloze-english">${clozeResult.display}</div>
+            <div class="cloze-japanese">${escapeHtml(phrase.japanese)}</div>
+          </div>
+          ${phrase.situation ? `<div class="phrase-situation">【${escapeHtml(phrase.situation)}】</div>` : ''}
+        </div>
+        <div class="phrase-lines">
+          ${generateBaselineGroup()}
+          <div class="line-separator-small"></div>
+          ${generateBaselineGroup()}
+        </div>
+      </div>
+    `;
+  }
+
+  html += '</div>';
+
+  if (showAnswers) {
+    html += '<div class="cloze-answers">';
+    html += '<h4 class="cloze-answers-title">Answer Key</h4>';
+    html += '<div class="cloze-answers-grid">';
+    for (let i = 0; i < clozeResults.length; i++) {
+      const answerList = escapeHtml(clozeResults[i].answers.join(', '));
+      html += `<div class="cloze-answer-item"><span class="cloze-answer-number">${i + 1}.</span> ${answerList}</div>`;
+    }
+    html += '</div>';
+    html += '</div>';
+  }
+
+  html += '</div>';
+  return html;
+}
+
+function generateClozeText(text, blankType) {
+  const words = text.split(/(\s+)/);
+  const answers = [];
+
+  if (blankType === 'char') {
+    const processed = words.map((token) => {
+      if (/^\s+$/.test(token)) return token;
+      const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+      if (cleanWord.length < 3) return token;
+
+      const sightWord = SIGHT_WORD_MAP_DATA.get(cleanWord.toLowerCase());
+      if (sightWord && (sightWord.blankType === 'char' || sightWord.blankType === 'both')) {
+        const pattern = sightWord.phonicsPattern;
+        const lowerClean = cleanWord.toLowerCase();
+        const patternIndex = lowerClean.indexOf(pattern.toLowerCase());
+
+        if (patternIndex >= 0) {
+          const prefix = cleanWord.substring(0, patternIndex);
+          const blanked = '_'.repeat(pattern.length);
+          const suffix = cleanWord.substring(patternIndex + pattern.length);
+          const punctuation = token.substring(cleanWord.length);
+          answers.push(pattern);
+          return `<span class="cloze-blank-char">${prefix}<span class="cloze-blank">${blanked}</span>${suffix}</span>${punctuation}`;
+        }
+      }
+
+      if (cleanWord.length >= 4) {
+        const midStart = Math.floor(cleanWord.length * 0.3);
+        const midEnd = Math.ceil(cleanWord.length * 0.7);
+        const blankedPart = cleanWord.substring(midStart, midEnd);
+        const prefix = cleanWord.substring(0, midStart);
+        const blanked = '_'.repeat(midEnd - midStart);
+        const suffix = cleanWord.substring(midEnd);
+        const punctuation = token.substring(cleanWord.length);
+        answers.push(blankedPart);
+        return `<span class="cloze-blank-char">${prefix}<span class="cloze-blank">${blanked}</span>${suffix}</span>${punctuation}`;
+      }
+
+      return token;
+    });
+
+    return { display: processed.join(''), answers };
+  }
+
+  // word-level blanks
+  let blankedCount = 0;
+  const maxBlanks = Math.max(1, Math.ceil(words.filter((w) => !/^\s+$/.test(w)).length * 0.3));
+
+  const processed = words.map((token) => {
+    if (/^\s+$/.test(token)) return token;
+    if (blankedCount >= maxBlanks) return token;
+
+    const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+    if (cleanWord.length < 2) return token;
+
+    if (SIGHT_WORD_SET_DATA.has(cleanWord.toLowerCase())) {
+      blankedCount++;
+      const blankWidth = Math.max(cleanWord.length * 2, 6);
+      const punctuation = token.substring(cleanWord.length);
+      answers.push(cleanWord);
+      return `<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${punctuation}`;
+    }
+
+    return token;
+  });
+
+  if (answers.length === 0) {
+    const contentWordEntries = words
+      .map((w, i) => ({ w, i }))
+      .filter(({ w }) => !/^\s+$/.test(w) && w.replace(/[.,!?;:'"()]/g, '').length >= 2);
+    if (contentWordEntries.length > 0) {
+      const target = contentWordEntries[Math.floor(contentWordEntries.length / 2)];
+      const cleanWord = target.w.replace(/[.,!?;:'"()]/g, '');
+      const blankWidth = Math.max(cleanWord.length * 2, 6);
+      const punctuation = target.w.substring(cleanWord.length);
+      answers.push(cleanWord);
+      processed[target.i] =
+        `<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${punctuation}`;
+    }
+  }
+
+  return { display: processed.join(''), answers };
+}
+
+function ensureClozeSequence(category, ageGroup, perPage, pageCount, phrases) {
+  const key = `${category}|${ageGroup}`;
+  const totalNeeded = perPage * pageCount;
+  const fingerprint = phrases.map((phrase) => phrase?.english || '').join('|');
+  const needsRefresh =
+    clozeSequenceCache.key !== key ||
+    clozeSequenceCache.perPage !== perPage ||
+    clozeSequenceCache.pageCount !== pageCount ||
+    clozeSequenceCache.sequence.length < totalNeeded ||
+    clozeSequenceCache.fingerprint !== fingerprint;
+
+  if (needsRefresh) {
+    const shuffled = shuffleArray([...phrases]);
+    const extended =
+      shuffled.length >= totalNeeded ? shuffled : buildExtendedSequence(shuffled, totalNeeded);
+
+    clozeSequenceCache = {
+      key,
+      perPage,
+      pageCount,
+      fingerprint,
+      sequence: extended.slice(0, totalNeeded),
+    };
+  }
+
+  return clozeSequenceCache.sequence;
 }
 
 // Phase 2: カスタム例文機能

--- a/script.js
+++ b/script.js
@@ -2039,7 +2039,7 @@ function generateClozeText(text, blankType) {
   if (blankType === 'char') {
     const processed = words.map((token) => {
       if (/^\s+$/.test(token)) return escapeHtml(token);
-      const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+      const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
       if (cleanWord.length < 3) return escapeHtml(token);
 
       const { leading, trailing } = extractPunctuation(token, cleanWord);
@@ -2083,7 +2083,7 @@ function generateClozeText(text, blankType) {
     if (/^\s+$/.test(token)) return token;
     if (blankedCount >= maxBlanks) return escapeHtml(token);
 
-    const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+    const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
     if (cleanWord.length < 2) return escapeHtml(token);
 
     if (SIGHT_WORD_SET_DATA.has(cleanWord.toLowerCase())) {

--- a/script.js
+++ b/script.js
@@ -2019,16 +2019,30 @@ function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride 
   return html;
 }
 
+function extractPunctuation(token, cleanWord) {
+  const lowerToken = token.toLowerCase();
+  const lowerClean = cleanWord.toLowerCase();
+  const wordIndex = lowerToken.indexOf(lowerClean);
+  if (wordIndex < 0) {
+    return { leading: '', trailing: token.substring(cleanWord.length) };
+  }
+  return {
+    leading: token.substring(0, wordIndex),
+    trailing: token.substring(wordIndex + cleanWord.length),
+  };
+}
+
 function generateClozeText(text, blankType) {
   const words = text.split(/(\s+)/);
   const answers = [];
 
   if (blankType === 'char') {
     const processed = words.map((token) => {
-      if (/^\s+$/.test(token)) return token;
+      if (/^\s+$/.test(token)) return escapeHtml(token);
       const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
-      if (cleanWord.length < 3) return token;
+      if (cleanWord.length < 3) return escapeHtml(token);
 
+      const { leading, trailing } = extractPunctuation(token, cleanWord);
       const sightWord = SIGHT_WORD_MAP_DATA.get(cleanWord.toLowerCase());
       if (sightWord && (sightWord.blankType === 'char' || sightWord.blankType === 'both')) {
         const pattern = sightWord.phonicsPattern;
@@ -2039,9 +2053,8 @@ function generateClozeText(text, blankType) {
           const prefix = cleanWord.substring(0, patternIndex);
           const blanked = '_'.repeat(pattern.length);
           const suffix = cleanWord.substring(patternIndex + pattern.length);
-          const punctuation = token.substring(cleanWord.length);
           answers.push(pattern);
-          return `<span class="cloze-blank-char">${prefix}<span class="cloze-blank">${blanked}</span>${suffix}</span>${punctuation}`;
+          return `${escapeHtml(leading)}<span class="cloze-blank-char">${escapeHtml(prefix)}<span class="cloze-blank">${blanked}</span>${escapeHtml(suffix)}</span>${escapeHtml(trailing)}`;
         }
       }
 
@@ -2052,12 +2065,11 @@ function generateClozeText(text, blankType) {
         const prefix = cleanWord.substring(0, midStart);
         const blanked = '_'.repeat(midEnd - midStart);
         const suffix = cleanWord.substring(midEnd);
-        const punctuation = token.substring(cleanWord.length);
         answers.push(blankedPart);
-        return `<span class="cloze-blank-char">${prefix}<span class="cloze-blank">${blanked}</span>${suffix}</span>${punctuation}`;
+        return `${escapeHtml(leading)}<span class="cloze-blank-char">${escapeHtml(prefix)}<span class="cloze-blank">${blanked}</span>${escapeHtml(suffix)}</span>${escapeHtml(trailing)}`;
       }
 
-      return token;
+      return escapeHtml(token);
     });
 
     return { display: processed.join(''), answers };
@@ -2069,20 +2081,20 @@ function generateClozeText(text, blankType) {
 
   const processed = words.map((token) => {
     if (/^\s+$/.test(token)) return token;
-    if (blankedCount >= maxBlanks) return token;
+    if (blankedCount >= maxBlanks) return escapeHtml(token);
 
     const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
-    if (cleanWord.length < 2) return token;
+    if (cleanWord.length < 2) return escapeHtml(token);
 
     if (SIGHT_WORD_SET_DATA.has(cleanWord.toLowerCase())) {
       blankedCount++;
+      const { leading, trailing } = extractPunctuation(token, cleanWord);
       const blankWidth = Math.max(cleanWord.length * 2, 6);
-      const punctuation = token.substring(cleanWord.length);
       answers.push(cleanWord);
-      return `<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${punctuation}`;
+      return `${escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${escapeHtml(trailing)}`;
     }
 
-    return token;
+    return escapeHtml(token);
   });
 
   if (answers.length === 0) {
@@ -2092,11 +2104,11 @@ function generateClozeText(text, blankType) {
     if (contentWordEntries.length > 0) {
       const target = contentWordEntries[Math.floor(contentWordEntries.length / 2)];
       const cleanWord = target.w.replace(/[.,!?;:'"()]/g, '');
+      const { leading, trailing } = extractPunctuation(target.w, cleanWord);
       const blankWidth = Math.max(cleanWord.length * 2, 6);
-      const punctuation = target.w.substring(cleanWord.length);
       answers.push(cleanWord);
       processed[target.i] =
-        `<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${punctuation}`;
+        `${escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${escapeHtml(trailing)}`;
     }
   }
 

--- a/src/data/sight-words.js
+++ b/src/data/sight-words.js
@@ -1,0 +1,94 @@
+/**
+ * サイトワード（高頻出語）データ
+ * Dolch Sight Wordsベースの高頻度語リスト（7-9歳向け中心）
+ *
+ * blankType:
+ *   - 'word': 単語レベルの穴埋め（文中の単語を空欄にする）
+ *   - 'char': 文字レベルの穴埋め（単語内の文字を空欄にする）
+ *   - 'both': 両方で使用可能
+ *
+ * phonicsPattern: フォニックスパターン（文字レベル穴埋め時のヒント）
+ */
+
+export const SIGHT_WORDS = [
+  // --- 基本動詞 ---
+  { word: 'are', japanese: '〜です', blankType: 'word', phonicsPattern: 'ar' },
+  { word: 'is', japanese: '〜です', blankType: 'word', phonicsPattern: 'is' },
+  { word: 'am', japanese: '〜です', blankType: 'word', phonicsPattern: 'am' },
+  { word: 'was', japanese: '〜でした', blankType: 'word', phonicsPattern: 'as' },
+  { word: 'were', japanese: '〜でした', blankType: 'word', phonicsPattern: 'ere' },
+  { word: 'do', japanese: 'する', blankType: 'word', phonicsPattern: 'oo' },
+  { word: 'does', japanese: 'する', blankType: 'word', phonicsPattern: 'oe' },
+  { word: 'did', japanese: 'した', blankType: 'word', phonicsPattern: 'id' },
+  { word: 'have', japanese: '持っている', blankType: 'both', phonicsPattern: 'ave' },
+  { word: 'has', japanese: '持っている', blankType: 'word', phonicsPattern: 'as' },
+  { word: 'can', japanese: 'できる', blankType: 'both', phonicsPattern: 'an' },
+  { word: 'will', japanese: '〜するつもり', blankType: 'word', phonicsPattern: 'ill' },
+  { word: 'like', japanese: '好き', blankType: 'both', phonicsPattern: 'ike' },
+  { word: 'want', japanese: '欲しい', blankType: 'both', phonicsPattern: 'ant' },
+  { word: 'come', japanese: '来る', blankType: 'both', phonicsPattern: 'ome' },
+  { word: 'go', japanese: '行く', blankType: 'word', phonicsPattern: 'go' },
+  { word: 'see', japanese: '見る', blankType: 'both', phonicsPattern: 'ee' },
+  { word: 'look', japanese: '見る', blankType: 'both', phonicsPattern: 'ook' },
+  { word: 'play', japanese: '遊ぶ', blankType: 'both', phonicsPattern: 'ay' },
+  { word: 'make', japanese: '作る', blankType: 'both', phonicsPattern: 'ake' },
+  { word: 'help', japanese: '助ける', blankType: 'both', phonicsPattern: 'elp' },
+  { word: 'know', japanese: '知る', blankType: 'both', phonicsPattern: 'ow' },
+  { word: 'think', japanese: '思う', blankType: 'both', phonicsPattern: 'th' },
+  { word: 'thank', japanese: '感謝する', blankType: 'both', phonicsPattern: 'th' },
+
+  // --- 代名詞・冠詞 ---
+  { word: 'you', japanese: 'あなた', blankType: 'word', phonicsPattern: 'ou' },
+  { word: 'your', japanese: 'あなたの', blankType: 'word', phonicsPattern: 'our' },
+  { word: 'my', japanese: '私の', blankType: 'word', phonicsPattern: 'my' },
+  { word: 'the', japanese: 'その', blankType: 'word', phonicsPattern: 'th' },
+  { word: 'this', japanese: 'これ', blankType: 'both', phonicsPattern: 'th' },
+  { word: 'that', japanese: 'あれ', blankType: 'both', phonicsPattern: 'th' },
+  { word: 'they', japanese: '彼ら', blankType: 'word', phonicsPattern: 'th' },
+  { word: 'we', japanese: '私たち', blankType: 'word', phonicsPattern: 'we' },
+  { word: 'he', japanese: '彼', blankType: 'word', phonicsPattern: 'he' },
+  { word: 'she', japanese: '彼女', blankType: 'word', phonicsPattern: 'sh' },
+  { word: 'it', japanese: 'それ', blankType: 'word', phonicsPattern: 'it' },
+
+  // --- 前置詞・接続詞 ---
+  { word: 'to', japanese: '〜へ', blankType: 'word', phonicsPattern: 'oo' },
+  { word: 'in', japanese: '〜の中に', blankType: 'word', phonicsPattern: 'in' },
+  { word: 'on', japanese: '〜の上に', blankType: 'word', phonicsPattern: 'on' },
+  { word: 'at', japanese: '〜で', blankType: 'word', phonicsPattern: 'at' },
+  { word: 'for', japanese: '〜のために', blankType: 'word', phonicsPattern: 'or' },
+  { word: 'with', japanese: '〜と一緒に', blankType: 'both', phonicsPattern: 'ith' },
+  { word: 'and', japanese: 'と', blankType: 'word', phonicsPattern: 'and' },
+  { word: 'but', japanese: 'でも', blankType: 'word', phonicsPattern: 'ut' },
+
+  // --- 形容詞・副詞 ---
+  { word: 'good', japanese: '良い', blankType: 'both', phonicsPattern: 'oo' },
+  { word: 'nice', japanese: '素敵な', blankType: 'both', phonicsPattern: 'ice' },
+  { word: 'fine', japanese: '元気な', blankType: 'both', phonicsPattern: 'ine' },
+  { word: 'happy', japanese: '嬉しい', blankType: 'both', phonicsPattern: 'appy' },
+  { word: 'sorry', japanese: 'ごめん', blankType: 'both', phonicsPattern: 'orry' },
+  { word: 'please', japanese: 'お願い', blankType: 'both', phonicsPattern: 'ea' },
+  { word: 'very', japanese: 'とても', blankType: 'word', phonicsPattern: 'ery' },
+  { word: 'how', japanese: 'どう', blankType: 'word', phonicsPattern: 'ow' },
+  { word: 'what', japanese: '何', blankType: 'word', phonicsPattern: 'wh' },
+  { word: 'where', japanese: 'どこ', blankType: 'word', phonicsPattern: 'wh' },
+  { word: 'when', japanese: 'いつ', blankType: 'word', phonicsPattern: 'wh' },
+
+  // --- 名詞（高頻出） ---
+  { word: 'name', japanese: '名前', blankType: 'both', phonicsPattern: 'ame' },
+  { word: 'day', japanese: '日', blankType: 'both', phonicsPattern: 'ay' },
+  { word: 'time', japanese: '時間', blankType: 'both', phonicsPattern: 'ime' },
+  { word: 'home', japanese: '家', blankType: 'both', phonicsPattern: 'ome' },
+  { word: 'school', japanese: '学校', blankType: 'both', phonicsPattern: 'ool' },
+  { word: 'friend', japanese: '友達', blankType: 'both', phonicsPattern: 'iend' },
+  { word: 'morning', japanese: '朝', blankType: 'both', phonicsPattern: 'ing' },
+];
+
+/**
+ * サイトワードのセットを取得（wordで検索用）
+ */
+export const SIGHT_WORD_SET = new Set(SIGHT_WORDS.map((sw) => sw.word.toLowerCase()));
+
+/**
+ * サイトワードのマップ（高速検索用）
+ */
+export const SIGHT_WORD_MAP = new Map(SIGHT_WORDS.map((sw) => [sw.word.toLowerCase(), sw]));

--- a/src/services/NoteGeneratorService.ts
+++ b/src/services/NoteGeneratorService.ts
@@ -16,6 +16,7 @@ import { ErrorHandler } from '../utils/ErrorHandler.js';
 import { ValidationService } from './ValidationService.js';
 import { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
 import { getDataManager, CATEGORY_DISPLAY_NAMES } from '../data/index.js';
+import { SIGHT_WORD_SET, SIGHT_WORD_MAP } from '../data/sight-words.js';
 import type {
   AgeGroup,
   SentenceContentItem,
@@ -414,17 +415,22 @@ export class NoteGeneratorService {
     const phrases = await this.getPhrasesForCategory(clozeCategory, state.ageGroup);
     const shuffledPhrases = this.shuffleArray([...phrases]).slice(0, 4);
     const categoryNames = this.getPhraseCategoryNames();
+    const blankType = state.clozeBlankType || 'word';
 
     let html = '<div class="cloze-practice">';
     html += `<h3 class="practice-title practice-title--cloze">Fill in the Blanks - ${categoryNames[clozeCategory] || clozeCategory}</h3>`;
     html += '<div class="cloze-grid">';
 
-    for (const phrase of shuffledPhrases) {
+    const clozeResults = shuffledPhrases.map((p) => this.generateClozeBlank(p.english, blankType));
+
+    for (let i = 0; i < shuffledPhrases.length; i++) {
+      const phrase = shuffledPhrases[i];
+      const clozeResult = clozeResults[i];
       html += `
         <div class="cloze-item">
           <div class="cloze-header">
             <div class="cloze-main">
-              <div class="cloze-english">${this.escapeHtml(phrase.english)}</div>
+              <div class="cloze-english">${clozeResult.display}</div>
               <div class="cloze-japanese">${this.escapeHtml(phrase.japanese)}</div>
             </div>
           </div>
@@ -440,6 +446,104 @@ export class NoteGeneratorService {
     html += '</div>';
     html += '</div>';
     return html;
+  }
+
+  private extractPunctuation(
+    token: string,
+    cleanWord: string
+  ): { leading: string; trailing: string } {
+    const wordIndex = token.toLowerCase().indexOf(cleanWord.toLowerCase());
+    if (wordIndex < 0) {
+      return { leading: '', trailing: token.substring(cleanWord.length) };
+    }
+    return {
+      leading: token.substring(0, wordIndex),
+      trailing: token.substring(wordIndex + cleanWord.length),
+    };
+  }
+
+  private generateClozeBlank(
+    text: string,
+    blankType: string
+  ): { display: string; answers: string[] } {
+    const words = text.split(/(\s+)/);
+    const answers: string[] = [];
+
+    if (blankType === 'char') {
+      const processed = words.map((token) => {
+        if (/^\s+$/.test(token)) return this.escapeHtml(token);
+        const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+        if (cleanWord.length < 3) return this.escapeHtml(token);
+
+        const { leading, trailing } = this.extractPunctuation(token, cleanWord);
+        const sightWord = SIGHT_WORD_MAP.get(cleanWord.toLowerCase());
+        if (sightWord && (sightWord.blankType === 'char' || sightWord.blankType === 'both')) {
+          const pattern = sightWord.phonicsPattern;
+          const patternIndex = cleanWord.toLowerCase().indexOf(pattern.toLowerCase());
+          if (patternIndex >= 0) {
+            const prefix = cleanWord.substring(0, patternIndex);
+            const blanked = '_'.repeat(pattern.length);
+            const suffix = cleanWord.substring(patternIndex + pattern.length);
+            answers.push(pattern);
+            return `${this.escapeHtml(leading)}<span class="cloze-blank-char">${this.escapeHtml(prefix)}<span class="cloze-blank">${blanked}</span>${this.escapeHtml(suffix)}</span>${this.escapeHtml(trailing)}`;
+          }
+        }
+
+        if (cleanWord.length >= 4) {
+          const midStart = Math.floor(cleanWord.length * 0.3);
+          const midEnd = Math.ceil(cleanWord.length * 0.7);
+          const blankedPart = cleanWord.substring(midStart, midEnd);
+          const prefix = cleanWord.substring(0, midStart);
+          const blanked = '_'.repeat(midEnd - midStart);
+          const suffix = cleanWord.substring(midEnd);
+          answers.push(blankedPart);
+          return `${this.escapeHtml(leading)}<span class="cloze-blank-char">${this.escapeHtml(prefix)}<span class="cloze-blank">${blanked}</span>${this.escapeHtml(suffix)}</span>${this.escapeHtml(trailing)}`;
+        }
+
+        return this.escapeHtml(token);
+      });
+
+      return { display: processed.join(''), answers };
+    }
+
+    // word-level blanks
+    let blankedCount = 0;
+    const maxBlanks = Math.max(1, Math.ceil(words.filter((w) => !/^\s+$/.test(w)).length * 0.3));
+
+    const processed = words.map((token) => {
+      if (/^\s+$/.test(token)) return token;
+      if (blankedCount >= maxBlanks) return this.escapeHtml(token);
+
+      const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+      if (cleanWord.length < 2) return this.escapeHtml(token);
+
+      if (SIGHT_WORD_SET.has(cleanWord.toLowerCase())) {
+        blankedCount++;
+        const { leading, trailing } = this.extractPunctuation(token, cleanWord);
+        const blankWidth = Math.max(cleanWord.length * 2, 6);
+        answers.push(cleanWord);
+        return `${this.escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${this.escapeHtml(trailing)}`;
+      }
+
+      return this.escapeHtml(token);
+    });
+
+    if (answers.length === 0) {
+      const contentWordEntries = words
+        .map((w, i) => ({ w, i }))
+        .filter(({ w }) => !/^\s+$/.test(w) && w.replace(/[.,!?;:'"()]/g, '').length >= 2);
+      if (contentWordEntries.length > 0) {
+        const target = contentWordEntries[Math.floor(contentWordEntries.length / 2)];
+        const cleanWord = target.w.replace(/[.,!?;:'"()]/g, '');
+        const { leading, trailing } = this.extractPunctuation(target.w, cleanWord);
+        const blankWidth = Math.max(cleanWord.length * 2, 6);
+        answers.push(cleanWord);
+        processed[target.i] =
+          `${this.escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${this.escapeHtml(trailing)}`;
+      }
+    }
+
+    return { display: processed.join(''), answers };
   }
 
   /**

--- a/src/services/NoteGeneratorService.ts
+++ b/src/services/NoteGeneratorService.ts
@@ -52,7 +52,7 @@ export class NoteGeneratorService {
       await this.validateUIState(state);
 
       // ランダムコンテンツを含むモードはキャッシュをスキップ
-      const randomModes = ['sentence', 'word', 'phrase'];
+      const randomModes = ['sentence', 'word', 'phrase', 'cloze'];
       const useCache = !randomModes.includes(state.practiceMode);
 
       // Check cache first (non-random modes only)
@@ -472,7 +472,7 @@ export class NoteGeneratorService {
     if (blankType === 'char') {
       const processed = words.map((token) => {
         if (/^\s+$/.test(token)) return this.escapeHtml(token);
-        const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+        const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
         if (cleanWord.length < 3) return this.escapeHtml(token);
 
         const { leading, trailing } = this.extractPunctuation(token, cleanWord);
@@ -514,7 +514,7 @@ export class NoteGeneratorService {
       if (/^\s+$/.test(token)) return token;
       if (blankedCount >= maxBlanks) return this.escapeHtml(token);
 
-      const cleanWord = token.replace(/[.,!?;:'"()]/g, '');
+      const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
       if (cleanWord.length < 2) return this.escapeHtml(token);
 
       if (SIGHT_WORD_SET.has(cleanWord.toLowerCase())) {
@@ -531,10 +531,12 @@ export class NoteGeneratorService {
     if (answers.length === 0) {
       const contentWordEntries = words
         .map((w, i) => ({ w, i }))
-        .filter(({ w }) => !/^\s+$/.test(w) && w.replace(/[.,!?;:'"()]/g, '').length >= 2);
+        .filter(
+          ({ w }) => !/^\s+$/.test(w) && w.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '').length >= 2
+        );
       if (contentWordEntries.length > 0) {
         const target = contentWordEntries[Math.floor(contentWordEntries.length / 2)];
-        const cleanWord = target.w.replace(/[.,!?;:'"()]/g, '');
+        const cleanWord = target.w.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
         const { leading, trailing } = this.extractPunctuation(target.w, cleanWord);
         const blankWidth = Math.max(cleanWord.length * 2, 6);
         answers.push(cleanWord);

--- a/src/services/NoteGeneratorService.ts
+++ b/src/services/NoteGeneratorService.ts
@@ -130,6 +130,9 @@ export class NoteGeneratorService {
         case 'phrase':
           html += await this.generatePhrasePractice(state);
           break;
+        case 'cloze':
+          html += await this.generateClozePractice(state);
+          break;
         case 'normal':
         default:
           html += await this.generateNormalPractice(state);
@@ -402,6 +405,39 @@ export class NoteGeneratorService {
       `;
     }
 
+    html += '</div>';
+    return html;
+  }
+
+  private async generateClozePractice(state: UIState): Promise<string> {
+    const clozeCategory = state.selectedCategories?.cloze || 'greetings';
+    const phrases = await this.getPhrasesForCategory(clozeCategory, state.ageGroup);
+    const shuffledPhrases = this.shuffleArray([...phrases]).slice(0, 4);
+    const categoryNames = this.getPhraseCategoryNames();
+
+    let html = '<div class="cloze-practice">';
+    html += `<h3 class="practice-title practice-title--cloze">Fill in the Blanks - ${categoryNames[clozeCategory] || clozeCategory}</h3>`;
+    html += '<div class="cloze-grid">';
+
+    for (const phrase of shuffledPhrases) {
+      html += `
+        <div class="cloze-item">
+          <div class="cloze-header">
+            <div class="cloze-main">
+              <div class="cloze-english">${this.escapeHtml(phrase.english)}</div>
+              <div class="cloze-japanese">${this.escapeHtml(phrase.japanese)}</div>
+            </div>
+          </div>
+          <div class="phrase-lines">
+            ${this.generateBaselineGroup()}
+            <div class="line-separator-small"></div>
+            ${this.generateBaselineGroup()}
+          </div>
+        </div>
+      `;
+    }
+
+    html += '</div>';
     html += '</div>';
     return html;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,10 +188,12 @@ export interface UIState {
   wordCategory: WordCategory;
   phraseCategory: PhraseCategory;
   alphabetType: AlphabetType;
+  clozeBlankType?: 'word' | 'char';
   selectedCategories?: {
     sentence?: ContentCategory;
     word?: WordCategory;
     phrase?: PhraseCategory;
+    cloze?: PhraseCategory;
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ export type AgeGroup = '4-6' | '7-9' | '10-12';
 /**
  * Practice modes available in the application
  */
-export type PracticeMode = 'normal' | 'sentence' | 'word' | 'alphabet' | 'phrase';
+export type PracticeMode = 'normal' | 'sentence' | 'word' | 'alphabet' | 'phrase' | 'cloze';
 
 /**
  * Line height options for baseline grids (in mm)
@@ -532,7 +532,7 @@ export function isAgeGroup(value: unknown): value is AgeGroup {
 export function isPracticeMode(value: unknown): value is PracticeMode {
   return (
     typeof value === 'string' &&
-    ['normal', 'sentence', 'word', 'alphabet', 'phrase'].includes(value)
+    ['normal', 'sentence', 'word', 'alphabet', 'phrase', 'cloze'].includes(value)
   );
 }
 

--- a/styles.css
+++ b/styles.css
@@ -839,8 +839,19 @@ body::before {
   .baseline-group,
   .sentence-practice-group,
   .example-sentence,
-  .phrase-item {
+  .phrase-item,
+  .cloze-item {
     page-break-inside: avoid !important;
+  }
+
+  /* 穴埋め練習の印刷時調整 */
+  .cloze-blank {
+    color: #000 !important;
+    border-bottom-color: #000 !important;
+  }
+
+  .cloze-answers {
+    border-top-color: #999 !important;
   }
 
   /* フレーズ練習の印刷時調整 */
@@ -1048,6 +1059,28 @@ body::before {
   font-size: 8pt;
   background: none;
   border: 1px solid #cbd5f5;
+}
+
+.a4-preview-page .cloze-practice {
+  padding: 0;
+}
+
+.a4-preview-page .cloze-grid {
+  grid-template-columns: 1fr;
+  gap: 3mm 5mm;
+}
+
+.a4-preview-page .cloze-item {
+  margin-bottom: 0;
+  page-break-inside: avoid;
+}
+
+.a4-preview-page .cloze-english {
+  font-size: 12pt;
+}
+
+.a4-preview-page .cloze-japanese {
+  font-size: 9.5pt;
 }
 
 /* プレビューでのベースライン色調整 */
@@ -1312,6 +1345,105 @@ body::before {
   font-size: 10pt;
   color: #64748b;
   margin: 8mm 0;
+}
+
+/* === 穴埋めフレーズ練習（Cloze Practice） === */
+
+.cloze-practice {
+  padding: 0;
+}
+
+.practice-title--cloze {
+  margin-bottom: 2mm;
+}
+
+.cloze-type-label {
+  text-align: center;
+  font-size: 9pt;
+  color: #64748b;
+  margin-bottom: 4mm;
+}
+
+.cloze-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3mm 5mm;
+}
+
+.cloze-item {
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5mm;
+  page-break-inside: avoid;
+}
+
+.cloze-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 4mm;
+}
+
+.cloze-main {
+  flex: 1;
+}
+
+.cloze-english {
+  font-size: 12pt;
+  font-weight: 600;
+  color: var(--text-color);
+  line-height: 1.4;
+}
+
+.cloze-japanese {
+  font-size: 9.5pt;
+  color: #606f7b;
+  margin-top: 0.5mm;
+  line-height: 1.2;
+}
+
+.cloze-blank {
+  display: inline;
+  font-family: monospace;
+  font-weight: 700;
+  color: #3b82f6;
+  letter-spacing: 0.15em;
+  border-bottom: 2px solid #3b82f6;
+  padding: 0 1px;
+}
+
+.cloze-blank-char {
+  font-weight: 600;
+}
+
+.cloze-answers {
+  margin-top: 5mm;
+  padding-top: 3mm;
+  border-top: 1px dashed #cbd5e1;
+}
+
+.cloze-answers-title {
+  font-size: 10pt;
+  font-weight: 700;
+  color: #475569;
+  margin-bottom: 2mm;
+}
+
+.cloze-answers-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1mm 6mm;
+}
+
+.cloze-answer-item {
+  font-size: 9pt;
+  color: #64748b;
+}
+
+.cloze-answer-number {
+  font-weight: 600;
+  color: #475569;
 }
 
 /* 練習モード共通のタイトル */

--- a/tests/e2e/cloze-practice-test.spec.js
+++ b/tests/e2e/cloze-practice-test.spec.js
@@ -1,0 +1,169 @@
+/**
+ * 穴埋めフレーズ練習モードのE2Eテスト
+ * cloze モードの各機能が正しく動作することを確認
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('穴埋めフレーズ練習テスト', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000');
+    await page.selectOption('#practiceMode', 'cloze');
+    await page.waitForTimeout(500);
+  });
+
+  test('穴埋めフレーズ練習オプションがプルダウンに存在する', async ({ page }) => {
+    const option = page.locator('#practiceMode option[value="cloze"]');
+    await expect(option).toHaveCount(1);
+
+    const text = await option.textContent();
+    expect(text).toContain('穴埋めフレーズ練習');
+  });
+
+  test('clozeモード選択時にclozeOptionsパネルが表示される', async ({ page }) => {
+    await expect(page.locator('#clozeOptions')).toBeVisible();
+
+    // cloze固有のコントロールが表示されていることを確認
+    await expect(page.locator('#clozeCategory')).toBeVisible();
+    await expect(page.locator('#clozeBlankType')).toBeVisible();
+    await expect(page.locator('#showClozeAnswers')).toBeVisible();
+  });
+
+  test('プレビューに空欄（cloze-blank要素）が生成される', async ({ page }) => {
+    // プレビューが生成されるのを待つ
+    await page.waitForTimeout(500);
+
+    const blanks = page.locator('#notePreview .cloze-blank');
+    const count = await blanks.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('単語レベルの穴埋めが正しく動作する', async ({ page }) => {
+    await page.selectOption('#clozeBlankType', 'word');
+    await page.waitForTimeout(500);
+
+    const previewHtml = await page.locator('#notePreview').innerHTML();
+
+    // 単語レベルではアンダースコアを含むcloze-blank要素が存在する
+    expect(previewHtml).toContain('cloze-blank');
+    const blanks = page.locator('#notePreview .cloze-blank');
+    const count = await blanks.count();
+    expect(count).toBeGreaterThan(0);
+
+    // 少なくとも1つの空欄にアンダースコアが含まれている
+    const firstBlank = await blanks.first().textContent();
+    expect(firstBlank).toMatch(/_+/);
+  });
+
+  test('文字レベルの穴埋めが正しく動作する', async ({ page }) => {
+    await page.selectOption('#clozeBlankType', 'char');
+    await page.waitForTimeout(500);
+
+    const previewHtml = await page.locator('#notePreview').innerHTML();
+
+    // 文字レベルでもcloze-blank要素が存在する
+    expect(previewHtml).toContain('cloze-blank');
+    const blanks = page.locator('#notePreview .cloze-blank');
+    const count = await blanks.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('単語レベルと文字レベルで異なる出力が生成される', async ({ page }) => {
+    // 単語レベル
+    await page.selectOption('#clozeBlankType', 'word');
+    await page.waitForTimeout(500);
+    const wordHtml = await page.locator('#notePreview').innerHTML();
+
+    // 文字レベルに切り替え
+    await page.selectOption('#clozeBlankType', 'char');
+    await page.waitForTimeout(500);
+    const charHtml = await page.locator('#notePreview').innerHTML();
+
+    // 両方ともcloze-blankを含むが、出力内容が異なる
+    expect(wordHtml).toContain('cloze-blank');
+    expect(charHtml).toContain('cloze-blank');
+
+    // 文字レベルではcloze-blank-char要素が含まれる
+    expect(charHtml).toContain('cloze-blank-char');
+  });
+
+  test('解答表示チェックボックスで解答セクションが表示・非表示になる', async ({ page }) => {
+    // デフォルトでは解答が非表示
+    const answersCheckbox = page.locator('#showClozeAnswers');
+    const isChecked = await answersCheckbox.isChecked();
+
+    if (!isChecked) {
+      // 解答セクションが非表示であることを確認
+      const answers = page.locator('#notePreview .cloze-answers');
+      const answersCount = await answers.count();
+      expect(answersCount).toBe(0);
+
+      // チェックボックスをオンにする
+      await answersCheckbox.check();
+      await page.waitForTimeout(500);
+
+      // 解答セクションが表示されることを確認
+      const answersAfter = page.locator('#notePreview .cloze-answers');
+      const answersCountAfter = await answersAfter.count();
+      expect(answersCountAfter).toBeGreaterThan(0);
+    } else {
+      // 既にチェック済みの場合、解答が表示されていることを確認
+      const answers = page.locator('#notePreview .cloze-answers');
+      await expect(answers.first()).toBeVisible();
+
+      // チェックを外す
+      await answersCheckbox.uncheck();
+      await page.waitForTimeout(500);
+
+      // 解答セクションが非表示になることを確認
+      const answersAfter = page.locator('#notePreview .cloze-answers');
+      const answersCountAfter = await answersAfter.count();
+      expect(answersCountAfter).toBe(0);
+    }
+  });
+
+  test('解答表示をオンにすると Answer Key が表示される', async ({ page }) => {
+    await page.locator('#showClozeAnswers').check();
+    await page.waitForTimeout(500);
+
+    const previewContent = await page.locator('#notePreview').textContent();
+    expect(previewContent).toContain('Answer Key');
+  });
+
+  test('カテゴリー選択でコンテンツが変わる', async ({ page }) => {
+    // あいさつカテゴリーを選択
+    await page.selectOption('#clozeCategory', 'greetings');
+    await page.waitForTimeout(500);
+    const greetingsContent = await page.locator('#notePreview').textContent();
+
+    // 買い物カテゴリーに切り替え
+    await page.selectOption('#clozeCategory', 'shopping');
+    await page.waitForTimeout(500);
+    const shoppingContent = await page.locator('#notePreview').textContent();
+
+    // 異なるカテゴリーで異なるコンテンツが表示される
+    expect(greetingsContent).not.toEqual(shoppingContent);
+  });
+
+  test('複数カテゴリーが切り替え可能', async ({ page }) => {
+    const categories = [
+      'greetings',
+      'self_introduction',
+      'school',
+      'shopping',
+      'travel',
+      'feelings',
+      'daily_life',
+    ];
+
+    for (const category of categories) {
+      await page.selectOption('#clozeCategory', category);
+      await page.waitForTimeout(300);
+
+      // 各カテゴリーでcloze-blank要素が生成されることを確認
+      const blanks = page.locator('#notePreview .cloze-blank');
+      const count = await blanks.count();
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add new "穴埋めフレーズ練習" (cloze/fill-in-the-blank) practice mode with sight words and phonics support
- Support two blank granularities: word-level (replace sight words) and character-level (phonics-targeted letter blanking)
- Include answer key with show/hide toggle, category selector reusing existing phrase collections

Closes #19

## Changes
| File | Description |
|------|-------------|
| `src/data/sight-words.js` | New: 60+ high-frequency sight words (Dolch-based) with phonics patterns |
| `script.js` | Cloze generation logic, layout calculation, event handlers, XSS-safe HTML escaping |
| `index.html` | New practice mode option + cloze controls panel |
| `styles.css` | Cloze-specific styles for blanks, answers, print media |
| `src/types/index.ts` | Added `'cloze'` to `PracticeMode` type |
| `src/services/NoteGeneratorService.ts` | Added cloze case in TypeScript service layer |
| `tests/e2e/cloze-practice-test.spec.js` | 10 E2E tests covering all acceptance criteria |

## Acceptance Criteria Coverage
- [x] 穴埋めフレーズ練習モードが追加される
- [x] 既存フレーズコレクションを使用し、空欄付きで出力される
- [x] 穴埋め粒度が選択可能（単語レベル vs 文字/フォニックスレベル）
- [x] 空欄はサイトワード/フォニックスターゲットに基づいて選択（ランダムではない）
- [x] 解答キーが表示/非表示トグルで利用可能
- [x] E2Eテストで検証済み（10テスト × 3ブラウザ = 30パス）

## Test plan
- [x] 既存ユニットテスト 118件パス
- [x] 新規E2Eテスト 30件パス (Chromium, WebKit, Mobile Safari)
- [x] リンター 0エラー
- [x] コンテンツテスト 47件パス
- [x] レイアウトテスト 25件パス
- [ ] ブラウザで穴埋めモードを選択し、プレビューに空欄が表示されることを確認
- [ ] 印刷プレビューでA4レイアウトが崩れないことを確認
- [ ] 解答キーのトグルが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)