### PR TITLE
fix(cloze): increase questions per page and hide notice from print

### DIFF
--- a/script.js
+++ b/script.js
@@ -401,12 +401,14 @@ function getPreviewState() {
   const lineHeightElement = document.getElementById('lineHeight');
   const showExamplesElement = document.getElementById('showExamples');
   const showTranslationElement = document.getElementById('showTranslation');
+  const showClozeAnswersElement = document.getElementById('showClozeAnswers');
   const pageCountInput = document.getElementById('pageCount');
 
   const practiceMode = practiceModeElement ? practiceModeElement.value : 'normal';
   const lineHeight = parseInt(lineHeightElement ? lineHeightElement.value : '10', 10);
   const showExamples = Boolean(showExamplesElement?.checked);
   const showTranslation = Boolean(showTranslationElement?.checked);
+  const showClozeAnswers = Boolean(showClozeAnswersElement?.checked);
 
   const maxAttr = pageCountInput?.getAttribute('max');
   const maxPageCount = Number.isFinite(parseInt(maxAttr || '', 10)) ? parseInt(maxAttr, 10) : 20;
@@ -422,6 +424,7 @@ function getPreviewState() {
     lineHeight: Number.isFinite(lineHeight) ? lineHeight : 10,
     showExamples,
     showTranslation,
+    showClozeAnswers,
     pageCount,
   };
 }
@@ -555,7 +558,7 @@ function calculateBaseLayout(state) {
     sentence: calculateSentencePracticeLayout(state.lineHeight, state.showTranslation),
     word: calculateWordPracticeLayout(state.lineHeight),
     phrase: calculatePhrasePracticeLayout(state.lineHeight),
-    cloze: calculateClozePracticeLayout(state.lineHeight),
+    cloze: calculateClozePracticeLayout(state.lineHeight, state.showClozeAnswers),
   };
 }
 
@@ -1883,8 +1886,8 @@ function ensurePhraseSequence(category, ageGroup, perPage, pageCount, phrases) {
 
 // === 穴埋めフレーズ練習（Cloze Practice） ===
 
-function calculateClozePracticeLayout(lineHeight) {
-  const basePhrases = getClozeCapacity(lineHeight);
+function calculateClozePracticeLayout(lineHeight, showAnswers = false) {
+  const basePhrases = getClozeCapacity(lineHeight, showAnswers);
   const minPhrases = Math.max(1, Math.min(basePhrases - 1, Math.floor(basePhrases * 0.7)));
 
   return {
@@ -1895,14 +1898,36 @@ function calculateClozePracticeLayout(lineHeight) {
   };
 }
 
-function getClozeCapacity(lineHeight) {
+function getClozeCapacity(lineHeight, showAnswers = false) {
   const availableHeight = 277;
   const headerHeight = 12;
   const gapHeight = 2;
   const itemHeight = headerHeight + lineHeight + gapHeight;
   const titleAreaHeight = 15;
   const usableHeight = availableHeight - titleAreaHeight;
-  const maxItems = Math.max(1, Math.floor(usableHeight / itemHeight));
+  const answersPerRow = 2;
+  const answersSectionTop = 12;
+  const answerRowHeight = 4;
+  const answerRowGap = 1;
+
+  let maxItems = Math.max(1, Math.floor(usableHeight / itemHeight));
+  maxItems = Math.min(10, maxItems);
+
+  if (showAnswers) {
+    while (maxItems > 1) {
+      const answerRows = Math.ceil(maxItems / answersPerRow);
+      const answerRowsHeight =
+        answerRows * answerRowHeight + Math.max(0, answerRows - 1) * answerRowGap;
+      const totalHeight = maxItems * itemHeight + answersSectionTop + answerRowsHeight;
+
+      if (totalHeight <= usableHeight) {
+        break;
+      }
+
+      maxItems -= 1;
+    }
+  }
+
   return Math.min(10, Math.max(2, maxItems));
 }
 
@@ -1938,7 +1963,7 @@ function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride 
     `;
   }
 
-  const layoutInfo = calculateClozePracticeLayout(lineHeight);
+  const layoutInfo = calculateClozePracticeLayout(lineHeight, showAnswers);
   const clozesPerPage = resolveLayoutValue(layoutInfo, layoutOverride?.clozesPerPage);
   const pageCount = Math.max(1, totalPages || 1);
   const phrases = ensureClozeSequence(

--- a/script.js
+++ b/script.js
@@ -1897,11 +1897,13 @@ function calculateClozePracticeLayout(lineHeight) {
 
 function getClozeCapacity(lineHeight) {
   const availableHeight = 277;
-  const itemHeight = 20 + 2 * lineHeight;
-  const maxItems = Math.max(1, Math.floor(availableHeight / itemHeight));
-  const safetyFactor = lineHeight >= 12 ? 0.5 : 0.55;
-  const safeItems = Math.max(1, Math.floor(maxItems * safetyFactor));
-  return Math.min(4, Math.max(2, safeItems));
+  const headerHeight = 12;
+  const gapHeight = 2;
+  const itemHeight = headerHeight + lineHeight + gapHeight;
+  const titleAreaHeight = 15;
+  const usableHeight = availableHeight - titleAreaHeight;
+  const maxItems = Math.max(1, Math.floor(usableHeight / itemHeight));
+  return Math.min(10, Math.max(2, maxItems));
 }
 
 function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride = {}) {
@@ -1993,8 +1995,6 @@ function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride 
           ${phrase.situation ? `<div class="phrase-situation">【${escapeHtml(phrase.situation)}】</div>` : ''}
         </div>
         <div class="phrase-lines">
-          ${generateBaselineGroup()}
-          <div class="line-separator-small"></div>
           ${generateBaselineGroup()}
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -734,7 +734,8 @@ body::before {
   .controls,
   .header,
   .footer,
-  .page-separator {
+  .page-separator,
+  .auto-layout-notice {
     display: none !important;
   }
 
@@ -1067,7 +1068,7 @@ body::before {
 
 .a4-preview-page .cloze-grid {
   grid-template-columns: 1fr;
-  gap: 3mm 5mm;
+  gap: 1.5mm 5mm;
 }
 
 .a4-preview-page .cloze-item {
@@ -1367,14 +1368,14 @@ body::before {
 .cloze-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 3mm 5mm;
+  gap: 1.5mm 5mm;
 }
 
 .cloze-item {
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.5mm;
+  gap: 1mm;
   page-break-inside: avoid;
 }
 


### PR DESCRIPTION
## Summary
- 穴埋め問題の1ページあたりの問題数を増加（上限4→10、練習行を2行→1行に削減、CSS gapを縮小）
- `getClozeCapacity()` の計算を正確なレイアウト高さに基づくように修正
- 自動調整通知（`.auto-layout-notice`）が印刷時に表示されてA4からはみ出す問題を修正

## Test plan
- [x] ユニットテスト 118件パス
- [x] E2Eテスト（cloze） 30件パス
- [ ] ブラウザで穴埋めモードを選択し、問題数が増えていることを確認
- [ ] 印刷プレビューでA4に収まることを確認
- [ ] 印刷プレビューに自動調整メッセージが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)