### PR TITLE
fix(cloze): 同一ページ内のフレーズ重複を解消 + 難易度プリセット導入

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,15 @@
             </select>
           </label>
           <label class="controls__label">
+            難易度:
+            <select id="clozeDifficulty" class="controls__select">
+              <option value="auto">自動（年齢に合わせる）</option>
+              <option value="easy">やさしい（穴 約20%・基本語のみ）</option>
+              <option value="normal">ふつう（穴 約30%）</option>
+              <option value="hard">むずかしい（穴 約50%・内容語も）</option>
+            </select>
+          </label>
+          <label class="controls__label">
             <input type="checkbox" id="showClozeAnswers" class="controls__checkbox" />
             解答を表示
           </label>

--- a/script.js
+++ b/script.js
@@ -2453,13 +2453,23 @@ function buildClozePagedSequence(source, perPage, pageCount) {
     const pageItems = [];
 
     if (source.length >= perPage) {
-      let candidates = shuffleArray(source);
-      // Avoid carryover from previous page when the pool is large enough to do so.
-      if (prevPageKeys.size > 0 && source.length >= perPage + prevPageKeys.size) {
-        const filtered = candidates.filter((p) => !prevPageKeys.has(p?.english));
-        if (filtered.length >= perPage) candidates = filtered;
+      const candidates = shuffleArray(source);
+      // Best-effort cross-page dedup: take as many "fresh" (not on previous page)
+      // items as possible, then top up with previously-used items if needed.
+      // When the pool is large enough that a fully-fresh page is feasible, this
+      // degenerates to picking only fresh items.
+      if (prevPageKeys.size > 0) {
+        const fresh = candidates.filter((p) => !prevPageKeys.has(p?.english));
+        const used = candidates.filter((p) => prevPageKeys.has(p?.english));
+        const freshCount = Math.min(fresh.length, perPage);
+        pageItems.push(...fresh.slice(0, freshCount));
+        const remaining = perPage - freshCount;
+        if (remaining > 0) {
+          pageItems.push(...shuffleArray(used).slice(0, remaining));
+        }
+      } else {
+        pageItems.push(...candidates.slice(0, perPage));
       }
-      pageItems.push(...candidates.slice(0, perPage));
     } else {
       // Pool smaller than perPage: take all of one shuffle, then top up with more
       // shuffles. Within a single page items will be as unique as possible until

--- a/script.js
+++ b/script.js
@@ -290,6 +290,7 @@ function setupEventListeners() {
     previewBtn: document.getElementById('previewBtn'),
     clozeCategory: document.getElementById('clozeCategory'),
     clozeBlankType: document.getElementById('clozeBlankType'),
+    clozeDifficulty: document.getElementById('clozeDifficulty'),
     showClozeAnswers: document.getElementById('showClozeAnswers'),
     shuffleClozeBtn: document.getElementById('shuffleCloze'),
   };
@@ -378,6 +379,10 @@ function setupEventListeners() {
     updatePreview();
   });
   addEventListenerIfExists(elements.clozeBlankType, 'change', updatePreview);
+  addEventListenerIfExists(elements.clozeDifficulty, 'change', () => {
+    resetClozeCache();
+    updatePreview();
+  });
   addEventListenerIfExists(elements.showClozeAnswers, 'change', updatePreview);
   addEventListenerIfExists(elements.shuffleClozeBtn, 'click', () => {
     resetClozeCache();
@@ -2159,12 +2164,24 @@ function getClozeCapacity(lineHeight, showAnswers = false) {
   return Math.min(10, Math.max(2, maxItems));
 }
 
+function resolveClozeDifficulty(rawDifficulty, ageGroup) {
+  const valid = ['easy', 'normal', 'hard'];
+  if (valid.includes(rawDifficulty)) return rawDifficulty;
+  // 'auto' or invalid → derive from ageGroup
+  if (ageGroup === '4-6') return 'easy';
+  if (ageGroup === '10-12') return 'hard';
+  return 'normal';
+}
+
 function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride = {}) {
   let html = '<div class="cloze-practice">';
   const clozeCategoryElement = document.getElementById('clozeCategory');
   const clozeCategory = (clozeCategoryElement && clozeCategoryElement.value) || 'greetings';
   const blankTypeElement = document.getElementById('clozeBlankType');
   const blankType = (blankTypeElement && blankTypeElement.value) || 'word';
+  const difficultyElement = document.getElementById('clozeDifficulty');
+  const rawDifficulty = (difficultyElement && difficultyElement.value) || 'auto';
+  const difficulty = resolveClozeDifficulty(rawDifficulty, ageGroup);
   const showAnswers = Boolean(document.getElementById('showClozeAnswers')?.checked);
   const lineHeight = parseInt(document.getElementById('lineHeight').value);
 
@@ -2199,7 +2216,8 @@ function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride 
     ageGroup,
     clozesPerPage,
     pageCount,
-    safePhrases
+    safePhrases,
+    difficulty
   );
 
   const startIndex = (pageNumber - 1) * clozesPerPage;
@@ -2228,12 +2246,14 @@ function generateClozePractice(pageNumber, totalPages, ageGroup, layoutOverride 
   };
 
   const blankTypeLabel = blankType === 'char' ? '文字レベル' : '単語レベル';
+  const difficultyLabels = { easy: 'やさしい', normal: 'ふつう', hard: 'むずかしい' };
+  const difficultyLabel = difficultyLabels[difficulty] || 'ふつう';
   const pageLabel = pageCount > 1 ? ` (${pageNumber}/${pageCount})` : '';
   html += `<h3 class="practice-title practice-title--cloze">Fill in the Blanks - ${categoryNames[clozeCategory] || clozeCategory}${pageLabel}</h3>`;
-  html += `<p class="cloze-type-label">${blankTypeLabel}</p>`;
+  html += `<p class="cloze-type-label">${blankTypeLabel}・${difficultyLabel}</p>`;
   html += '<div class="cloze-grid">';
 
-  const clozeResults = pagePhrases.map((p) => generateClozeText(p.english, blankType));
+  const clozeResults = pagePhrases.map((p) => generateClozeText(p.english, blankType, difficulty));
 
   for (let i = 0; i < pagePhrases.length; i++) {
     const phrase = pagePhrases[i];
@@ -2285,23 +2305,56 @@ function extractPunctuation(token, cleanWord) {
   };
 }
 
-function generateClozeText(text, blankType) {
+// Difficulty presets controlling blank ratio and which kinds of words are
+// preferred as blanks. Higher score = more likely to be picked.
+const CLOZE_DIFFICULTY_PRESETS = {
+  easy: { ratio: 0.2, sightScore: 10, contentScore: 0, otherScore: 0 },
+  normal: { ratio: 0.3, sightScore: 6, contentScore: 3, otherScore: 1 },
+  hard: { ratio: 0.5, sightScore: 3, contentScore: 8, otherScore: 1 },
+};
+
+function getClozeDifficultyPreset(difficulty) {
+  return CLOZE_DIFFICULTY_PRESETS[difficulty] || CLOZE_DIFFICULTY_PRESETS.normal;
+}
+
+function buildWordBlankSpan(cleanWord) {
+  const blankWidth = Math.max(cleanWord.length * 2, 6);
+  return `<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>`;
+}
+
+function generateClozeText(text, blankType, difficulty = 'normal') {
   const words = text.split(/(\s+)/);
   const answers = [];
+  const preset = getClozeDifficultyPreset(difficulty);
 
   if (blankType === 'char') {
-    const processed = words.map((token) => {
+    // Char-level: collect candidate words first, then keep only a difficulty-
+    // dependent fraction. Selection within candidates is randomized so the same
+    // sentence can produce different blanks across regenerations.
+    const candidateIndexes = [];
+    words.forEach((token, i) => {
+      if (/^\s+$/.test(token)) return;
+      const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
+      if (cleanWord.length < 3) return;
+      candidateIndexes.push(i);
+    });
+
+    const charBlankRatio = { easy: 0.4, normal: 0.65, hard: 1.0 }[difficulty] ?? 0.65;
+    const targetCount = Math.max(1, Math.round(candidateIndexes.length * charBlankRatio));
+    const chosenIndexes = new Set(
+      shuffleArray([...candidateIndexes]).slice(0, Math.min(targetCount, candidateIndexes.length))
+    );
+
+    const processed = words.map((token, i) => {
       if (/^\s+$/.test(token)) return escapeHtml(token);
       const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
-      if (cleanWord.length < 3) return escapeHtml(token);
+      if (cleanWord.length < 3 || !chosenIndexes.has(i)) return escapeHtml(token);
 
       const { leading, trailing } = extractPunctuation(token, cleanWord);
       const sightWord = SIGHT_WORD_MAP_DATA.get(cleanWord.toLowerCase());
       if (sightWord && (sightWord.blankType === 'char' || sightWord.blankType === 'both')) {
         const pattern = sightWord.phonicsPattern;
-        const lowerClean = cleanWord.toLowerCase();
-        const patternIndex = lowerClean.indexOf(pattern.toLowerCase());
-
+        const patternIndex = cleanWord.toLowerCase().indexOf(pattern.toLowerCase());
         if (patternIndex >= 0) {
           const prefix = cleanWord.substring(0, patternIndex);
           const blanked = '_'.repeat(pattern.length);
@@ -2328,48 +2381,113 @@ function generateClozeText(text, blankType) {
     return { display: processed.join(''), answers };
   }
 
-  // word-level blanks
-  let blankedCount = 0;
-  const maxBlanks = Math.max(1, Math.ceil(words.filter((w) => !/^\s+$/.test(w)).length * 0.3));
-
-  const processed = words.map((token) => {
-    if (/^\s+$/.test(token)) return token;
-    if (blankedCount >= maxBlanks) return escapeHtml(token);
-
+  // word-level blanks: score every candidate word by difficulty, randomize
+  // within score tier, then take the top-N positions.
+  const wordEntries = [];
+  words.forEach((token, i) => {
+    if (/^\s+$/.test(token)) return;
     const cleanWord = token.replace(/^[.,!?;:'"()]+|[.,!?;:'"()]+$/g, '');
-    if (cleanWord.length < 2) return escapeHtml(token);
-
-    if (SIGHT_WORD_SET_DATA.has(cleanWord.toLowerCase())) {
-      blankedCount++;
-      const { leading, trailing } = extractPunctuation(token, cleanWord);
-      const blankWidth = Math.max(cleanWord.length * 2, 6);
-      answers.push(cleanWord);
-      return `${escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${escapeHtml(trailing)}`;
-    }
-
-    return escapeHtml(token);
+    if (cleanWord.length < 2) return;
+    const lower = cleanWord.toLowerCase();
+    const isSight = SIGHT_WORD_SET_DATA.has(lower);
+    // "Content word" ≈ non-sight word with substance: nouns/verbs/adjectives
+    // typically ≥3 chars. Cheap heuristic; good enough for early-learner text.
+    const isContent = !isSight && cleanWord.length >= 3;
+    let baseScore;
+    if (isSight) baseScore = preset.sightScore;
+    else if (isContent) baseScore = preset.contentScore;
+    else baseScore = preset.otherScore;
+    wordEntries.push({
+      token,
+      index: i,
+      cleanWord,
+      score: baseScore + Math.random(),
+    });
   });
 
-  if (answers.length === 0) {
-    const contentWordEntries = words
-      .map((w, i) => ({ w, i }))
-      .filter(({ w }) => !/^\s+$/.test(w) && w.replace(/[.,!?;:'"()]/g, '').length >= 2);
-    if (contentWordEntries.length > 0) {
-      const target = contentWordEntries[Math.floor(contentWordEntries.length / 2)];
-      const cleanWord = target.w.replace(/[.,!?;:'"()]/g, '');
-      const { leading, trailing } = extractPunctuation(target.w, cleanWord);
-      const blankWidth = Math.max(cleanWord.length * 2, 6);
-      answers.push(cleanWord);
-      processed[target.i] =
-        `${escapeHtml(leading)}<span class="cloze-blank" style="display:inline-block;min-width:${blankWidth}ch">${'_'.repeat(cleanWord.length)}</span>${escapeHtml(trailing)}`;
-    }
+  const totalWordCount = wordEntries.length;
+  const maxBlanks = Math.max(1, Math.round(totalWordCount * preset.ratio));
+
+  // Highest-score-first; ties broken by the random component already baked in.
+  const ranked = [...wordEntries].sort((a, b) => b.score - a.score);
+  // Filter out zero-score entries (e.g. easy mode has no sight words in the
+  // sentence — the fallback below will still ensure at least one blank).
+  const chosen = ranked.filter((e) => e.score >= 1).slice(0, maxBlanks);
+  const chosenByIndex = new Map(chosen.map((e) => [e.index, e]));
+
+  const processed = words.map((token, i) => {
+    if (/^\s+$/.test(token)) return token;
+    const entry = chosenByIndex.get(i);
+    if (!entry) return escapeHtml(token);
+    const { leading, trailing } = extractPunctuation(token, entry.cleanWord);
+    answers.push(entry.cleanWord);
+    return `${escapeHtml(leading)}${buildWordBlankSpan(entry.cleanWord)}${escapeHtml(trailing)}`;
+  });
+
+  // Fallback: if no candidate qualified (e.g. easy mode + sentence has zero
+  // sight words), blank the middle content word so the exercise is non-empty.
+  if (answers.length === 0 && wordEntries.length > 0) {
+    const target = wordEntries[Math.floor(wordEntries.length / 2)];
+    const { leading, trailing } = extractPunctuation(target.token, target.cleanWord);
+    answers.push(target.cleanWord);
+    processed[target.index] =
+      `${escapeHtml(leading)}${buildWordBlankSpan(target.cleanWord)}${escapeHtml(trailing)}`;
   }
 
   return { display: processed.join(''), answers };
 }
 
-function ensureClozeSequence(category, ageGroup, perPage, pageCount, phrases) {
-  const key = `${category}|${ageGroup}`;
+// Builds a sequence of `perPage * pageCount` phrases where each contiguous
+// page-sized window contains no duplicates (when source has at least `perPage`
+// unique items). When the source pool is smaller than what all pages need, it
+// reshuffles per page and tries to avoid items used on the previous page.
+function buildClozePagedSequence(source, perPage, pageCount) {
+  if (!Array.isArray(source) || source.length === 0 || perPage <= 0 || pageCount <= 0) {
+    return [];
+  }
+
+  const result = [];
+  let prevPageKeys = new Set();
+
+  for (let page = 0; page < pageCount; page++) {
+    const pageItems = [];
+
+    if (source.length >= perPage) {
+      let candidates = shuffleArray(source);
+      // Avoid carryover from previous page when the pool is large enough to do so.
+      if (prevPageKeys.size > 0 && source.length >= perPage + prevPageKeys.size) {
+        const filtered = candidates.filter((p) => !prevPageKeys.has(p?.english));
+        if (filtered.length >= perPage) candidates = filtered;
+      }
+      pageItems.push(...candidates.slice(0, perPage));
+    } else {
+      // Pool smaller than perPage: take all of one shuffle, then top up with more
+      // shuffles. Within a single page items will be as unique as possible until
+      // the pool is exhausted.
+      const seenKeys = new Set();
+      while (pageItems.length < perPage) {
+        const remaining = perPage - pageItems.length;
+        const fresh = shuffleArray(source).filter((p) => !seenKeys.has(p?.english));
+        if (fresh.length === 0) {
+          // Pool exhausted within page — must repeat. Reset seen and continue.
+          seenKeys.clear();
+          continue;
+        }
+        const take = fresh.slice(0, remaining);
+        take.forEach((p) => seenKeys.add(p?.english));
+        pageItems.push(...take);
+      }
+    }
+
+    result.push(...pageItems);
+    prevPageKeys = new Set(pageItems.map((p) => p?.english));
+  }
+
+  return result;
+}
+
+function ensureClozeSequence(category, ageGroup, perPage, pageCount, phrases, difficulty) {
+  const key = `${category}|${ageGroup}|${difficulty || 'auto'}`;
   const totalNeeded = perPage * pageCount;
   const fingerprint = phrases.map((phrase) => phrase?.english || '').join('|');
   const needsRefresh =
@@ -2380,16 +2498,14 @@ function ensureClozeSequence(category, ageGroup, perPage, pageCount, phrases) {
     clozeSequenceCache.fingerprint !== fingerprint;
 
   if (needsRefresh) {
-    const shuffled = shuffleArray([...phrases]);
-    const extended =
-      shuffled.length >= totalNeeded ? shuffled : buildExtendedSequence(shuffled, totalNeeded);
+    const sequence = buildClozePagedSequence(phrases, perPage, pageCount);
 
     clozeSequenceCache = {
       key,
       perPage,
       pageCount,
       fingerprint,
-      sequence: extended.slice(0, totalNeeded),
+      sequence,
     };
   }
 

--- a/tests/e2e/cloze-practice-test.spec.js
+++ b/tests/e2e/cloze-practice-test.spec.js
@@ -166,4 +166,39 @@ test.describe('穴埋めフレーズ練習テスト', () => {
       expect(count).toBeGreaterThan(0);
     }
   });
+
+  test('教室の英語を複数ページ生成しても同一ページ内にフレーズの重複が出ない', async ({ page }) => {
+    await page.selectOption('#clozeCategory', 'classroom_english');
+    await page.fill('#pageCount', '3');
+    await page.waitForTimeout(800);
+
+    const englishTexts = await page.locator('#notePreview .cloze-english').allTextContents();
+    expect(englishTexts.length).toBeGreaterThan(0);
+
+    // 各ページの cloze-practice ブロックごとにフレーズが一意であること
+    const pages = await page.locator('#notePreview .cloze-practice').all();
+    expect(pages.length).toBeGreaterThanOrEqual(2);
+    for (const pageBlock of pages) {
+      const items = await pageBlock.locator('.cloze-english').allTextContents();
+      const unique = new Set(items.map((s) => s.trim()));
+      expect(unique.size).toBe(items.length);
+    }
+  });
+
+  test('難易度セレクタが存在し、難易度ごとに穴の数が変わる', async ({ page }) => {
+    await expect(page.locator('#clozeDifficulty')).toBeVisible();
+    await page.selectOption('#clozeCategory', 'classroom_english');
+    await page.selectOption('#clozeBlankType', 'word');
+
+    await page.selectOption('#clozeDifficulty', 'easy');
+    await page.waitForTimeout(500);
+    const easyBlanks = await page.locator('#notePreview .cloze-blank').count();
+
+    await page.selectOption('#clozeDifficulty', 'hard');
+    await page.waitForTimeout(500);
+    const hardBlanks = await page.locator('#notePreview .cloze-blank').count();
+
+    // hard は easy より多くの穴を生成するはず
+    expect(hardBlanks).toBeGreaterThan(easyBlanks);
+  });
 });


### PR DESCRIPTION
## Summary

- 「教室の英語」など小さめのフレーズプールで穴埋め練習を生成すると、**同一ページ内に同じフレーズが重複表示される**バグを修正
- 難易度プリセット（auto / easy / normal / hard）を導入。年齢グループに自動連動 + 手動オーバーライド対応
- 穴の選択を**スコアリング + ランダム化**にし、同じ文を再生成すると違う箇所が穴になるよう変更（反復学習の効果向上）

## Root cause

\`buildExtendedSequence\` がプール枯渇時にその場で再シャッフルする実装で、再シャッフル境界が**ページ内に落ちる**ケースで同一ページ内重複が発生していた。例：\`classroom_english\` 7-9 歳（プール 12 件）× perPage 10 のとき、ページ 2 が \`shuffle1[10..11]\` + \`shuffle2[0..7]\` となりページ内で同じフレーズが出る。

## Changes

### \`script.js\`
- \`buildClozePagedSequence(source, perPage, pageCount)\` を新設。各ページ単位でシャッフル、前ページの登場語を可能なら除外
- \`ensureClozeSequence\` を新ビルダーに切替、キャッシュキーに \`difficulty\` を追加
- \`resolveClozeDifficulty(raw, ageGroup)\`：\`auto\` で 4-6→easy / 7-9→normal / 10-12→hard
- \`generateClozeText(text, blankType, difficulty)\` をリファクタ
  - \`CLOZE_DIFFICULTY_PRESETS\`：ratio = easy 0.2 / normal 0.3 / hard 0.5、sight word vs content word の重みを難易度ごとに切替
  - \`Math.random()\` でタイ破り → 同じ文でも穴位置がランダム化

### \`index.html\`
- \`#clozeOptions\` 内に \`#clozeDifficulty\` セレクタを追加

### \`tests/e2e/cloze-practice-test.spec.js\`
- 「教室の英語×3ページで同一ページ内重複ゼロ」テスト
- 「easy < hard で穴の数が増える」テスト

## Test plan

- [x] \`npx playwright test cloze-practice-test --project=chromium\` → 12/12 パス（既存 10 + 新規 2）
- [x] \`npx playwright test --project=chromium\` → 78 passed（残る failure/flaky は cloze 無関係の既存課題）
- [x] \`npm run test\` → 124/124 パス
- [x] \`npm run test:content\` / \`npm run test:layout\` → 全合格
- [ ] 手動：「教室の英語」+ 複数ページで重複が出ないこと、難易度切替で穴の数が変わることをブラウザで確認

## Follow-ups

- #24 \`classroom_english\` データの意味的近似ペア整理
- #25 word/phrase/sentence モードへの同様の対応展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)