### PR TITLE
fix(data): resolve near-duplicate phrases in classroom_english

### DIFF
--- a/src/data/collections/phrases/classroom_english.json
+++ b/src/data/collections/phrases/classroom_english.json
@@ -345,11 +345,11 @@
       "tags": ["classroom_english", "question"]
     },
     {
-      "id": "phrase-classroom_english-could-you-explain-that-again-10-12",
+      "id": "phrase-classroom_english-how-does-this-connect-to-the-l-10-12",
       "type": "phrase",
-      "english": "Could you explain that again?",
-      "japanese": "もう一度説明していただけますか？",
-      "situation": "再説明を求めるとき",
+      "english": "How does this connect to the lesson?",
+      "japanese": "これは今日の授業とどうつながっていますか？",
+      "situation": "内容と授業のつながりを確認するとき",
       "category": "classroom_english",
       "ageGroup": "10-12",
       "difficulty": 3,
@@ -359,11 +359,11 @@
       "tags": ["classroom_english", "question"]
     },
     {
-      "id": "phrase-classroom_english-what-does-this-mean-10-12",
+      "id": "phrase-classroom_english-why-is-this-important-10-12",
       "type": "phrase",
-      "english": "What does this mean?",
-      "japanese": "これはどういう意味ですか？",
-      "situation": "意味を尋ねるとき",
+      "english": "Why is this important?",
+      "japanese": "なぜこれは大切なのですか？",
+      "situation": "学ぶ意義や重要性を尋ねるとき",
       "category": "classroom_english",
       "ageGroup": "10-12",
       "difficulty": 3,

--- a/src/data/phrase-data.js
+++ b/src/data/phrase-data.js
@@ -1348,14 +1348,14 @@ export const PHRASE_DATA = {
     ],
     '10-12': [
       {
-        english: 'Could you explain that again?',
-        japanese: 'もう一度説明していただけますか？',
-        situation: '再説明を求めるとき',
+        english: 'How does this connect to the lesson?',
+        japanese: 'これは今日の授業とどうつながっていますか？',
+        situation: '内容と授業のつながりを確認するとき',
       },
       {
-        english: 'What does this mean?',
-        japanese: 'これはどういう意味ですか？',
-        situation: '意味を尋ねるとき',
+        english: 'Why is this important?',
+        japanese: 'なぜこれは大切なのですか？',
+        situation: '学ぶ意義や重要性を尋ねるとき',
       },
       {
         english: 'May I ask a question?',


### PR DESCRIPTION
## Summary

- `classroom_english` カテゴリの 10-12 グループに、7-9 グループとほぼ同義のフレーズが含まれており、穴埋め演習で「同じ問題を 2 回解いている」感覚を与えていた
- 重複の強い 2 フレーズを差し替え、`How` / `Why` 疑問文を新規追加して文型バリエーションを拡充
- 7-9 のシンプル版は年齢相応として残し、10-12 側だけを置換

Closes #24

## Before / After

| Age Group | Before | After | 理由 |
|-----------|--------|-------|------|
| 10-12 | `Could you explain that again?` | `How does this connect to the lesson?` | 7-9 の `Can you say that again?` と意味重複 → How 疑問文を導入 |
| 10-12 | `What does this mean?` | `Why is this important?` | 7-9 の `What does this word mean?` と意味重複 → Why 疑問文を導入 |
| 7-9 | `Can you say that again?` | (変更なし) | 年齢相応のシンプル表現として保持 |
| 7-9 | `What does this word mean?` | (変更なし) | 年齢相応のシンプル表現として保持 |

副次効果:
- 10-12 内の `Could you ...?` 構文: 3 → 2 件に減少（過剰集中を緩和）
- 文型多様性: How / Why 疑問文を新規追加
- `totalCount` は 36 のまま不変

## Files Changed

- `src/data/phrase-data.js` — 10-12 グループの 2 フレーズを差し替え
- `src/data/collections/phrases/classroom_english.json` — 並列 JSON ファイルを同一 ID 規約 (slug-30char + ageGroup) で同期

両ファイルは現在ミラー構成のため、片方のみの更新は整合性を崩します。本 PR では両方を同時に更新しています。

## Test Plan

### Automated
- [x] `npm run test:content` — 63/63 pass
- [x] `npm run test -- --run` — 124/124 pass
- [x] pre-commit hook (lint-staged + tests) all green
- [x] `npm run lint` — 既存の 3 エラー (`script.js:240-242`) のみ。本 PR とは無関係 (main にも存在)

### Manual
- [ ] 印刷プレビューで `classroom_english` の 10-12 グループに `How does this connect to the lesson?` / `Why is this important?` が表示されること
- [ ] 7-9 グループの `Can you say that again?` / `What does this word mean?` が引き続き表示されること
- [ ] 穴埋め (cloze) モードで同一ページ内に意味重複フレーズが出現しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)