### PR TITLE
feat(alphabet): beginner-friendly tracing — non-italic, full-line, repeated horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,9 +176,9 @@
             <select id="alphabetTraceRepeat" class="controls__select">
               <option value="1">1</option>
               <option value="2">2</option>
-              <option value="3">3</option>
+              <option value="3" selected>3</option>
               <option value="4">4</option>
-              <option value="5" selected>5</option>
+              <option value="5">5</option>
             </select>
           </label>
           <label class="controls__label">

--- a/index.html
+++ b/index.html
@@ -176,9 +176,9 @@
             <select id="alphabetTraceRepeat" class="controls__select">
               <option value="1">1</option>
               <option value="2">2</option>
-              <option value="3" selected>3</option>
+              <option value="3">3</option>
               <option value="4">4</option>
-              <option value="5">5</option>
+              <option value="5" selected>5</option>
             </select>
           </label>
           <label class="controls__label">
@@ -351,7 +351,7 @@
               class="controls__input"
               value="1"
               min="1"
-              max="20"
+              max="60"
             />
           </label>
         </div>

--- a/script.js
+++ b/script.js
@@ -1822,27 +1822,16 @@ function generateAlphabetPractice(pageNumber) {
     return '<div class="alphabet-practice"><p style="text-align: center; color: #999;">このページには表示する文字がありません</p></div>';
   }
 
-  // 必要なページ数を自動計算して設定
-  if (alphabetType === 'both' && pageNumber === 1) {
+  // 必要なページ数を自動計算（全文字を1巡表示できるよう pageCount を引き上げる）
+  if (pageNumber === 1) {
     const neededPages = Math.ceil(letters.length / lettersPerPage);
     const pageCountInput = document.getElementById('pageCount');
     if (pageCountInput && parseInt(pageCountInput.value) < neededPages) {
-      if (window.Debug)
-        window.Debug.info(
-          'ALPHABET_PRACTICE',
-          `アルファベット練習（両方）: ${neededPages}ページ必要です`
-        );
-      // ユーザーに通知
+      // 確認ダイアログなしで自動的にページ数を引き上げる
       setTimeout(() => {
-        if (
-          confirm(
-            `全${letters.length}文字を表示するには${neededPages}ページ必要です。ページ数を${neededPages}に変更しますか？`
-          )
-        ) {
-          pageCountInput.value = neededPages;
-          updatePreview();
-        }
-      }, 100);
+        pageCountInput.value = neededPages;
+        updatePreview();
+      }, 0);
     }
   }
 

--- a/script.js
+++ b/script.js
@@ -503,6 +503,11 @@ function updateOptionsVisibility() {
 
 // プレビュー更新
 function updatePreview() {
+  // アルファベット練習モードでは、全文字を1巡表示できるよう pageCount をレンダー前に同期で引き上げる
+  // （旧実装は generateAlphabetPractice 内の setTimeout で再帰的に updatePreview を呼んでおり、
+  //   不要な二重レンダリング＆ pageCount.max を超えると無限ループする恐れがあった）
+  bumpPageCountForAlphabet();
+
   const state = getPreviewState();
   const notePreview = document.getElementById('notePreview');
 
@@ -521,6 +526,46 @@ function updatePreview() {
   const adjustmentResult = autoAdjustPreview(notePreview, state, baseLayout, initialOverrides);
 
   updateAutoLayoutNotice(adjustmentResult, state, baseLayout);
+}
+
+// アルファベット練習で全文字を表示できる枚数を返す（モードでなければ null）
+function computeAlphabetNeededPages() {
+  const practiceMode = document.getElementById('practiceMode')?.value;
+  if (practiceMode !== 'alphabet') return null;
+
+  const alphabetType = document.getElementById('alphabetType')?.value || 'uppercase';
+  const alphabetMode = document.getElementById('alphabetMode')?.value || 'normal';
+  const isTrace = alphabetMode === 'trace';
+  const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 3);
+  const wordCount = clampInt(document.getElementById('alphabetWordCount')?.value, 1, 3, 2);
+  const showExample = Boolean(document.getElementById('showAlphabetExample')?.checked);
+
+  let total = 0;
+  if (alphabetType === 'uppercase' || alphabetType === 'both')
+    total += ALPHABET_DATA.uppercase?.length || 0;
+  if (alphabetType === 'lowercase' || alphabetType === 'both')
+    total += ALPHABET_DATA.lowercase?.length || 0;
+  if (total === 0) return null;
+
+  const lettersPerPage = isTrace
+    ? computeTraceLettersPerPage(traceRepeat, wordCount, showExample)
+    : 6;
+  return Math.ceil(total / lettersPerPage);
+}
+
+// 必要に応じて pageCount を引き上げ（max 属性で必ずキャップしてループ無限化を防ぐ）
+function bumpPageCountForAlphabet() {
+  const needed = computeAlphabetNeededPages();
+  if (!needed) return;
+  const pageCountInput = document.getElementById('pageCount');
+  if (!pageCountInput) return;
+  const maxAttr = parseInt(pageCountInput.getAttribute('max') || '', 10);
+  const maxPages = Number.isFinite(maxAttr) ? maxAttr : 60;
+  const target = Math.min(needed, maxPages);
+  const current = parseInt(pageCountInput.value, 10);
+  if (!Number.isFinite(current) || current < target) {
+    pageCountInput.value = String(target);
+  }
 }
 
 function getPreviewState() {
@@ -1836,18 +1881,8 @@ function generateAlphabetPractice(pageNumber) {
     return '<div class="alphabet-practice"><p style="text-align: center; color: #999;">このページには表示する文字がありません</p></div>';
   }
 
-  // 必要なページ数を自動計算（全文字を1巡表示できるよう pageCount を引き上げる）
-  if (pageNumber === 1) {
-    const neededPages = Math.ceil(letters.length / lettersPerPage);
-    const pageCountInput = document.getElementById('pageCount');
-    if (pageCountInput && parseInt(pageCountInput.value) < neededPages) {
-      // 確認ダイアログなしで自動的にページ数を引き上げる
-      setTimeout(() => {
-        pageCountInput.value = neededPages;
-        updatePreview();
-      }, 0);
-    }
-  }
+  // pageCount の自動引き上げは updatePreview() の bumpPageCountForAlphabet() が
+  // レンダー前に同期で済ませるため、ここでは何もしない（再帰呼び出し回避）。
 
   let html = '<div class="alphabet-practice">';
 

--- a/script.js
+++ b/script.js
@@ -1798,7 +1798,7 @@ function generateAlphabetPractice(pageNumber) {
   const showExample = document.getElementById('showAlphabetExample').checked;
   const alphabetMode = document.getElementById('alphabetMode')?.value || 'normal';
   const isTrace = alphabetMode === 'trace';
-  const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 3);
+  const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 5);
   const wordCount = clampInt(document.getElementById('alphabetWordCount')?.value, 1, 3, 2);
 
   let letters = [];

--- a/script.js
+++ b/script.js
@@ -1345,11 +1345,15 @@ function generateWordPractice(pageNumber, totalPages, ageGroup, layoutOverride =
 }
 
 // ベースライングループ生成
-function generateBaselineGroup(guideText = '') {
-  const traceGuide =
-    typeof guideText === 'string' && guideText.trim()
-      ? `<div class="guide-letter">${escapeHtml(guideText.trim())}</div>`
-      : '';
+// horizRepeat > 1 で薄字ガイドを行内に複数回繰り返し描画する（なぞり書き用）
+function generateBaselineGroup(guideText = '', horizRepeat = 1) {
+  let traceGuide = '';
+  if (typeof guideText === 'string' && guideText.trim()) {
+    const safe = escapeHtml(guideText.trim());
+    const count = Math.max(1, horizRepeat | 0);
+    const spans = Array.from({ length: count }, () => `<span>${safe}</span>`).join('');
+    traceGuide = `<div class="guide-letter">${spans}</div>`;
+  }
   const traceClass = traceGuide ? ' baseline-group--trace' : '';
 
   return `
@@ -1361,6 +1365,16 @@ function generateBaselineGroup(guideText = '') {
             <div class="baseline baseline--bottom"></div>
         </div>
     `;
+}
+
+// テキスト長に応じた行内なぞり数を返す（短い文字ほど多く並べる）
+function horizRepeatForText(text) {
+  const len = (text || '').trim().length;
+  if (len <= 1) return 7;
+  if (len <= 3) return 4;
+  if (len <= 5) return 3;
+  if (len <= 7) return 2;
+  return 2;
 }
 
 // 例文表示生成
@@ -1798,7 +1812,7 @@ function generateAlphabetPractice(pageNumber) {
   const showExample = document.getElementById('showAlphabetExample').checked;
   const alphabetMode = document.getElementById('alphabetMode')?.value || 'normal';
   const isTrace = alphabetMode === 'trace';
-  const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 5);
+  const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 3);
   const wordCount = clampInt(document.getElementById('alphabetWordCount')?.value, 1, 3, 2);
 
   let letters = [];
@@ -1895,11 +1909,12 @@ function generateAlphabetPractice(pageNumber) {
   return html;
 }
 
-// 薄字ガイド付きベースラインを n 本連続で生成
+// 薄字ガイド付きベースラインを n 本連続で生成（行内には複数回なぞれるよう horizRepeat 個並べる）
 function repeatBaselineGroup(guideText, count) {
+  const horiz = horizRepeatForText(guideText);
   let out = '';
   for (let i = 0; i < count; i++) {
-    out += generateBaselineGroup(guideText);
+    out += generateBaselineGroup(guideText, horiz);
   }
   return out;
 }

--- a/styles.css
+++ b/styles.css
@@ -468,13 +468,14 @@ body::before {
 .guide-letter {
   position: absolute;
   left: 3mm;
-  top: 0.6mm;
-  font-family: 'Century Schoolbook', 'Times New Roman', serif;
-  font-size: calc(var(--line-height-mm, 10mm) * 0.62);
+  top: -1.6mm;
+  font-family:
+    'Hiragino Maru Gothic ProN', 'Comic Sans MS', 'Andika', 'Yu Gothic', system-ui, sans-serif;
+  font-size: calc(var(--line-height-mm, 10mm) * 1.1);
   font-style: normal;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 1;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   color: #d6dce5;
   white-space: nowrap;
   pointer-events: none;

--- a/styles.css
+++ b/styles.css
@@ -471,7 +471,7 @@ body::before {
   top: 0.6mm;
   font-family: 'Century Schoolbook', 'Times New Roman', serif;
   font-size: calc(var(--line-height-mm, 10mm) * 0.62);
-  font-style: italic;
+  font-style: normal;
   font-weight: 600;
   line-height: 1;
   letter-spacing: 0.06em;

--- a/styles.css
+++ b/styles.css
@@ -468,6 +468,7 @@ body::before {
 .guide-letter {
   position: absolute;
   left: 3mm;
+  right: 3mm;
   top: -1.6mm;
   font-family:
     'Hiragino Maru Gothic ProN', 'Comic Sans MS', 'Andika', 'Yu Gothic', system-ui, sans-serif;
@@ -477,10 +478,19 @@ body::before {
   line-height: 1;
   letter-spacing: 0.04em;
   color: #d6dce5;
+  display: flex;
+  justify-content: space-around;
+  align-items: flex-start;
+  gap: 3mm;
   white-space: nowrap;
+  overflow: hidden;
   pointer-events: none;
   user-select: none;
   z-index: 1;
+}
+
+.guide-letter > span {
+  flex: 0 0 auto;
 }
 
 .baseline--top {

--- a/tests/e2e/alphabet-practice-test.spec.js
+++ b/tests/e2e/alphabet-practice-test.spec.js
@@ -201,6 +201,20 @@ test.describe('アルファベット練習モードテスト', () => {
     expect(pages * firstPageItems).toBeGreaterThanOrEqual(26);
   });
 
+  // pageCount の自動引き上げはレンダー前に同期で行われる（再帰 updatePreview を使わない）
+  test('alphabet モード切替直後に pageCount が即時に引き上がる', async ({ page }) => {
+    // pageCount を強制的に 1 にリセット
+    await page.evaluate(() => {
+      const el = document.getElementById('pageCount');
+      if (el) el.value = '1';
+    });
+    await page.selectOption('#alphabetType', 'uppercase');
+    await page.selectOption('#alphabetMode', 'trace');
+    // wait は最小限。同期で更新されるなら即時に増えているはず
+    const value = await page.locator('#pageCount').inputValue();
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(13);
+  });
+
   // .guide-letter は初学者向けに非斜体（normal）であること
   test('なぞり書きの薄字ガイドは斜体ではない', async ({ page }) => {
     await page.selectOption('#alphabetType', 'uppercase');

--- a/tests/e2e/alphabet-practice-test.spec.js
+++ b/tests/e2e/alphabet-practice-test.spec.js
@@ -74,12 +74,13 @@ test.describe('アルファベット練習モードテスト', () => {
 
   test('2列グリッドレイアウトで表示される', async ({ page }) => {
     const alphabetGrid = page.locator('.alphabet-grid');
-    await expect(alphabetGrid).toBeVisible();
+    await expect(alphabetGrid.first()).toBeVisible();
 
-    const gridItems = page.locator('.alphabet-grid-item');
-    const count = await gridItems.count();
+    // 1 ページ目に最大 6 文字（通常モード = 2×3 グリッド）
+    const firstPageItems = page.locator('.note-page').first().locator('.alphabet-grid-item');
+    const count = await firstPageItems.count();
     expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThanOrEqual(6); // 1ページに最大6文字
+    expect(count).toBeLessThanOrEqual(6);
   });
 
   test('例示単語数を増やすと複数の単語が表示される', async ({ page }) => {
@@ -122,10 +123,10 @@ test.describe('アルファベット練習モードテスト', () => {
     await page.selectOption('#alphabetMode', 'trace');
     await page.waitForTimeout(500);
 
-    const gridItems = page.locator('.alphabet-grid-item');
-    const count = await gridItems.count();
+    // 1 ページ目あたりの文字数を確認（既定 repeat=3, wordCount=2 → 2 文字/ページ）
+    const firstPageItems = page.locator('.note-page').first().locator('.alphabet-grid-item');
+    const count = await firstPageItems.count();
     expect(count).toBeGreaterThan(0);
-    // 既定 (repeat=3, wordCount=2) は 2 文字/ページに収まる
     expect(count).toBeLessThanOrEqual(2);
   });
 
@@ -175,12 +176,35 @@ test.describe('アルファベット練習モードテスト', () => {
 
   test('ページ数が自動調整される（両方モード）', async ({ page }) => {
     await page.selectOption('#alphabetType', 'both');
-    await page.waitForTimeout(1000); // ページ数調整のための待機
+    await page.waitForTimeout(500);
 
     const previewContent = await page.locator('#notePreview').textContent();
     // ページ情報が表示されることを確認
     const hasPageInfo = /\((\d+)\/(\d+)\)/.test(previewContent);
     expect(hasPageInfo).toBeTruthy();
+  });
+
+  // なぞり書きモード+大文字: 26 文字 / 2 letters per page = 13 ページが既定で必要
+  test('大文字なぞり書きの既定設定で 13 ページに自動調整される', async ({ page }) => {
+    await page.selectOption('#alphabetType', 'uppercase');
+    await page.selectOption('#alphabetMode', 'trace');
+    await page.waitForTimeout(500);
+
+    const pageCountValue = await page.locator('#pageCount').inputValue();
+    expect(parseInt(pageCountValue, 10)).toBeGreaterThanOrEqual(13);
+  });
+
+  // .guide-letter は初学者向けに非斜体（normal）であること
+  test('なぞり書きの薄字ガイドは斜体ではない', async ({ page }) => {
+    await page.selectOption('#alphabetType', 'uppercase');
+    await page.selectOption('#alphabetMode', 'trace');
+    await page.waitForTimeout(500);
+
+    const fontStyle = await page
+      .locator('.guide-letter')
+      .first()
+      .evaluate((el) => window.getComputedStyle(el).fontStyle);
+    expect(fontStyle).toBe('normal');
   });
 
   test('文字が大きく見やすく表示される', async ({ page }) => {

--- a/tests/e2e/alphabet-practice-test.spec.js
+++ b/tests/e2e/alphabet-practice-test.spec.js
@@ -184,14 +184,21 @@ test.describe('アルファベット練習モードテスト', () => {
     expect(hasPageInfo).toBeTruthy();
   });
 
-  // なぞり書きモード+大文字: 26 文字 / 2 letters per page = 13 ページが既定で必要
-  test('大文字なぞり書きの既定設定で 13 ページに自動調整される', async ({ page }) => {
+  // なぞり書きモード+大文字: 26 文字すべてを表示できる枚数に自動調整
+  test('大文字なぞり書きの既定設定で全 26 文字を表示できるよう自動調整される', async ({ page }) => {
     await page.selectOption('#alphabetType', 'uppercase');
     await page.selectOption('#alphabetMode', 'trace');
     await page.waitForTimeout(500);
 
     const pageCountValue = await page.locator('#pageCount').inputValue();
-    expect(parseInt(pageCountValue, 10)).toBeGreaterThanOrEqual(13);
+    const pages = parseInt(pageCountValue, 10);
+    // 1 ページあたりの文字数 × ページ数 ≥ 26
+    const firstPageItems = await page
+      .locator('.note-page')
+      .first()
+      .locator('.alphabet-grid-item')
+      .count();
+    expect(pages * firstPageItems).toBeGreaterThanOrEqual(26);
   });
 
   // .guide-letter は初学者向けに非斜体（normal）であること


### PR DESCRIPTION
## Summary

Alphabet Practice のなぞり書きモードを初学者向けに改善します。実スクショで複数回イテレーションして仕上げました。

### 1. 薄字ガイドのフォント刷新

- `font-style: italic → normal` (Century Schoolbook 斜体は子供には読みづらかった)
- `font-family` を Hiragino Maru Gothic ProN → Comic Sans MS → Andika → system-ui の sans-serif スタックに変更
- `font-size` を `0.62 → 1.1` 倍に拡大、`top` を調整して capital が **top dashed line ⇒ baseline** までフルに乗るように。lowercase も x-height にきっちり収まる
- 既存バグ修正: `window.Debug.info is not a function` で render を中断していた箇所を削除

### 2. なぞり書きを「横に並べる」方式に変更

これまでは 1 行に「A」が 1 個だけで右側が広い空白でした。行内に複数並べて、1 ページに 2 文字を収める構成にしました。

- `generateBaselineGroup(text, horizRepeat)` が `<span>` を N 個生成
- `.guide-letter` を `display: flex; justify-content: space-around` に変更し、行幅いっぱいに均等配置
- 文字長から自動で本数を決定 (`horizRepeatForText`):
  | 文字長 | 横の本数 | 例 |
  |---|---|---|
  | 1 char | 7 | A, B, X |
  | ≤3 char | 4 | Ant, Cat |
  | ≤5 char | 3 | Apple, Bear |
  | ≤7 char | 2 | Rabbit |
  | それ以上 | 2 | Elephant |

### 3. ページ数の自動調整

- アルファベット練習に切り替えると、全 26 (or 52) 文字が表示される枚数に `pageCount` を自動セット (`confirm()` ダイアログ廃止)
- `pageCount` の `max` を 20 → 60 に引き上げ (`both` モード+高密度に備えて)

### 既定設定の比較 (uppercase, trace)

| 観点 | Before (PR #29 マージ時) | After |
|---|---|---|
| 1 文字あたり総なぞり回数 | 1 (A が左端に 1 個) | **21** (7 横 × 3 縦) |
| 例示単語のなぞり回数 | 1 ずつ | **9** (3 横 × 3 縦) |
| 1 ページあたりの種類 | 6 (通常モード継承) | **2** (なぞり書き専用レイアウト) |
| 全 26 文字の表示 | 手動で 13 ページ設定が必要 | 自動で **13 ページ** にセット |
| ガイド文字 | Century Schoolbook **斜体**、4 本線の上 1/3 のみ占有 | Hiragino Maru Gothic **正立**、cap-height がフル |

## Files changed

- `index.html` — `#alphabetMode` / `#alphabetTraceRepeat` / `#alphabetWordCount` の既定値、`pageCount` max
- `script.js` — `generateBaselineGroup` 改修、`horizRepeatForText`、`computeTraceLettersPerPage`、`repeatBaselineGroup`、自動ページ数調整、broken `Debug.info` 除去
- `styles.css` — `.guide-letter` を flex 横並び化、`.alphabet-grid--tracing` / `.alphabet-trace-row` レイアウト
- `tests/e2e/alphabet-practice-test.spec.js` — 横なぞり / 非斜体 / ページ自動調整 / A4 はみ出しガード を追加

## Test plan

- [x] `npx playwright test tests/e2e/alphabet-practice-test.spec.js --project=chromium` — 15/15 pass
- [x] vitest 124/124, content/layout 89/89 (pre-commit hooks)
- [x] スクショで visual 確認 (italic→normal, 横並び, A4 内収納)
- [x] 高密度設定 (repeat=5, wordCount=3) でも `.note-page` が A4 1122.5px を越えないことを E2E で保証

🤖 Generated with [Claude Code](https://claude.com/claude-code)