### PR TITLE
fix(alphabet): align tracing guides with handwriting lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,6 @@
       </div>
     </div>
 
-    <script src="src/quality-validator.js"></script>
     <script src="src/debug-utils.js"></script>
     <script src="utils/LayoutValidator.js"></script>
     <script src="utils/PrintSimulator.js"></script>

--- a/script.js
+++ b/script.js
@@ -1413,14 +1413,14 @@ function generateBaselineGroup(guideText = '', horizRepeat = 1) {
     `;
 }
 
+const TRACE_ASCENDERS = new Set(['b', 'd', 'f', 'h', 'k', 'l', 't']);
+const TRACE_DESCENDERS = new Set(['g', 'j', 'p', 'q', 'y']);
+
 function getTraceGuideClass(text) {
   const value = (text || '').trim();
-  const ascenders = new Set(['b', 'd', 'f', 'h', 'k', 'l', 't']);
-  const descenders = new Set(['g', 'j', 'p', 'q', 'y']);
-
   if (/^[a-z]$/.test(value)) {
-    if (ascenders.has(value)) return 'guide-letter--lowercase-ascender';
-    if (descenders.has(value)) return 'guide-letter--lowercase-descender';
+    if (TRACE_ASCENDERS.has(value)) return 'guide-letter--lowercase-ascender';
+    if (TRACE_DESCENDERS.has(value)) return 'guide-letter--lowercase-descender';
     return 'guide-letter--lowercase-short';
   }
 
@@ -1927,7 +1927,7 @@ function generateAlphabetPractice(pageNumber) {
       // なぞり書き: 文字 + 例示単語ごとに薄字ガイド付きベースラインを repeat 本描画
       bodyHtml += `<div class="alphabet-trace-row">
                 <div class="alphabet-trace-label">${escapeHtml(item.letter)}</div>
-                <div class="alphabet-trace-lines">${repeatBaselineGroup(item.letter, traceRepeat)}</div>
+                <div class="alphabet-trace-lines">${repeatBaselineGroup(item.letter, traceRepeat, lineHeight)}</div>
             </div>`;
       if (showExample) {
         for (const word of itemWords) {
@@ -1936,7 +1936,7 @@ function generateAlphabetPractice(pageNumber) {
                         <span class="example-word">${escapeHtml(word.english)}</span>
                         <span class="example-meaning">(${escapeHtml(word.japanese)})</span>
                     </div>
-                    <div class="alphabet-trace-lines">${repeatBaselineGroup(word.english, traceRepeat)}</div>
+                    <div class="alphabet-trace-lines">${repeatBaselineGroup(word.english, traceRepeat, lineHeight)}</div>
                 </div>`;
         }
       }
@@ -1969,9 +1969,10 @@ function generateAlphabetPractice(pageNumber) {
 }
 
 // 薄字ガイド付きベースラインを n 本連続で生成（行内には複数回なぞれるよう horizRepeat 個並べる）
-function repeatBaselineGroup(guideText, count) {
-  const lineHeight = clampInt(document.getElementById('lineHeight')?.value, 8, 12, 10);
-  const horiz = horizRepeatForText(guideText, lineHeight);
+function repeatBaselineGroup(guideText, count, lineHeight = null) {
+  const effectiveLineHeight =
+    lineHeight ?? clampInt(document.getElementById('lineHeight')?.value, 8, 12, 10);
+  const horiz = horizRepeatForText(guideText, effectiveLineHeight);
   let out = '';
   for (let i = 0; i < count; i++) {
     out += generateBaselineGroup(guideText, horiz);

--- a/script.js
+++ b/script.js
@@ -538,6 +538,7 @@ function computeAlphabetNeededPages() {
   const isTrace = alphabetMode === 'trace';
   const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 3);
   const wordCount = clampInt(document.getElementById('alphabetWordCount')?.value, 1, 3, 2);
+  const lineHeight = clampInt(document.getElementById('lineHeight')?.value, 8, 12, 10);
   const showExample = Boolean(document.getElementById('showAlphabetExample')?.checked);
 
   let total = 0;
@@ -548,12 +549,12 @@ function computeAlphabetNeededPages() {
   if (total === 0) return null;
 
   const lettersPerPage = isTrace
-    ? computeTraceLettersPerPage(traceRepeat, wordCount, showExample)
+    ? computeTraceLettersPerPage(traceRepeat, wordCount, showExample, lineHeight)
     : 6;
   return Math.ceil(total / lettersPerPage);
 }
 
-// 必要に応じて pageCount を引き上げ（max 属性で必ずキャップしてループ無限化を防ぐ）
+// アルファベット練習では、文字種・罫線高さの変更に合わせて pageCount を同期する
 function bumpPageCountForAlphabet() {
   const needed = computeAlphabetNeededPages();
   if (!needed) return;
@@ -563,7 +564,7 @@ function bumpPageCountForAlphabet() {
   const maxPages = Number.isFinite(maxAttr) ? maxAttr : 60;
   const target = Math.min(needed, maxPages);
   const current = parseInt(pageCountInput.value, 10);
-  if (!Number.isFinite(current) || current < target) {
+  if (!Number.isFinite(current) || current !== target) {
     pageCountInput.value = String(target);
   }
 }
@@ -1397,7 +1398,7 @@ function generateBaselineGroup(guideText = '', horizRepeat = 1) {
     const safe = escapeHtml(guideText.trim());
     const count = Math.max(1, horizRepeat | 0);
     const spans = Array.from({ length: count }, () => `<span>${safe}</span>`).join('');
-    traceGuide = `<div class="guide-letter">${spans}</div>`;
+    traceGuide = `<div class="guide-letter ${getTraceGuideClass(guideText)}">${spans}</div>`;
   }
   const traceClass = traceGuide ? ' baseline-group--trace' : '';
 
@@ -1412,12 +1413,34 @@ function generateBaselineGroup(guideText = '', horizRepeat = 1) {
     `;
 }
 
+function getTraceGuideClass(text) {
+  const value = (text || '').trim();
+  const ascenders = new Set(['b', 'd', 'f', 'h', 'k', 'l', 't']);
+  const descenders = new Set(['g', 'j', 'p', 'q', 'y']);
+
+  if (/^[a-z]$/.test(value)) {
+    if (ascenders.has(value)) return 'guide-letter--lowercase-ascender';
+    if (descenders.has(value)) return 'guide-letter--lowercase-descender';
+    return 'guide-letter--lowercase-short';
+  }
+
+  if (/^[a-z]+$/.test(value)) {
+    return 'guide-letter--lowercase-word';
+  }
+
+  if (/^[A-Z][a-z]+$/.test(value)) {
+    return 'guide-letter--mixed-word';
+  }
+
+  return 'guide-letter--uppercase';
+}
+
 // テキスト長に応じた行内なぞり数を返す（短い文字ほど多く並べる）
-function horizRepeatForText(text) {
+function horizRepeatForText(text, lineHeight = 10) {
   const len = (text || '').trim().length;
   if (len <= 1) return 7;
-  if (len <= 3) return 4;
-  if (len <= 5) return 3;
+  if (len <= 3) return lineHeight >= 12 ? 3 : 4;
+  if (len <= 5) return lineHeight >= 12 ? 2 : 3;
   if (len <= 7) return 2;
   return 2;
 }
@@ -1859,6 +1882,7 @@ function generateAlphabetPractice(pageNumber) {
   const isTrace = alphabetMode === 'trace';
   const traceRepeat = clampInt(document.getElementById('alphabetTraceRepeat')?.value, 1, 5, 3);
   const wordCount = clampInt(document.getElementById('alphabetWordCount')?.value, 1, 3, 2);
+  const lineHeight = clampInt(document.getElementById('lineHeight')?.value, 8, 12, 10);
 
   let letters = [];
   if (alphabetType === 'uppercase' || alphabetType === 'both') {
@@ -1870,7 +1894,7 @@ function generateAlphabetPractice(pageNumber) {
 
   // 通常: 2列×3行=6 / なぞり書き: A4 高さ (297mm − 余白 − タイトル ≒ 260mm) に収まる文字数を密度から逆算
   const lettersPerPage = isTrace
-    ? computeTraceLettersPerPage(traceRepeat, wordCount, showExample)
+    ? computeTraceLettersPerPage(traceRepeat, wordCount, showExample, lineHeight)
     : 6;
   const startIndex = (pageNumber - 1) * lettersPerPage;
   const endIndex = startIndex + lettersPerPage;
@@ -1946,7 +1970,8 @@ function generateAlphabetPractice(pageNumber) {
 
 // 薄字ガイド付きベースラインを n 本連続で生成（行内には複数回なぞれるよう horizRepeat 個並べる）
 function repeatBaselineGroup(guideText, count) {
-  const horiz = horizRepeatForText(guideText);
+  const lineHeight = clampInt(document.getElementById('lineHeight')?.value, 8, 12, 10);
+  const horiz = horizRepeatForText(guideText, lineHeight);
   let out = '';
   for (let i = 0; i < count; i++) {
     out += generateBaselineGroup(guideText, horiz);
@@ -1962,13 +1987,15 @@ function clampInt(value, min, max, fallback) {
 }
 
 // なぞり書き時の 1 ページあたり文字数を A4 高さから逆算
-// ベースライン1本=10mm + 行間2mm=12mm。1セル=(1+wordCount)行 × repeat 本 + 行マージン3mm × 行数。
-// セル間ギャップ5mm、タイトル~10mm、ページパディング20mm を引いた約260mm を可用域とする。
-function computeTraceLettersPerPage(repeat, wordCount, showExample) {
+// 1セル=(1+wordCount)行 × repeat 本。罫線高さの設定に合わせて行間も再計算する。
+// タイトル、ページパディング、セル間ギャップを差し引き、例示単語ありでは少し保守的に見積もる。
+function computeTraceLettersPerPage(repeat, wordCount, showExample, lineHeight = 10) {
   const rowsPerCell = 1 + (showExample ? wordCount : 0);
-  const cellHeightMm = rowsPerCell * (repeat * 12 + 3);
+  const lineSpacingMm = Math.max(1, Math.floor(lineHeight * 0.2));
+  const rowMarginMm = 3;
+  const cellHeightMm = rowsPerCell * (repeat * (lineHeight + lineSpacingMm) + rowMarginMm);
   const interCellGapMm = 5;
-  const availableMm = 260;
+  const availableMm = showExample ? 250 : 260;
   const fit = Math.floor((availableMm + interCellGapMm) / (cellHeightMm + interCellGapMm));
   return Math.max(1, fit);
 }

--- a/styles.css
+++ b/styles.css
@@ -469,12 +469,15 @@ body::before {
 }
 
 .guide-letter {
+  --guide-font-scale: 1.08;
+  --guide-top-scale: -0.15;
+
   position: absolute;
   left: 3mm;
   right: 3mm;
-  top: -1.6mm;
+  top: calc(var(--line-height-mm, 10mm) * var(--guide-top-scale));
   font-family: var(--font-handwriting);
-  font-size: calc(var(--line-height-mm, 10mm) * 1.1);
+  font-size: calc(var(--line-height-mm, 10mm) * var(--guide-font-scale));
   font-style: normal;
   font-weight: 400;
   line-height: 1;
@@ -493,6 +496,31 @@ body::before {
 
 .guide-letter > span {
   flex: 0 0 auto;
+}
+
+.guide-letter--mixed-word {
+  --guide-font-scale: 1.02;
+  --guide-top-scale: -0.08;
+}
+
+.guide-letter--lowercase-short {
+  --guide-font-scale: 1;
+  --guide-top-scale: -0.03;
+}
+
+.guide-letter--lowercase-ascender {
+  --guide-font-scale: 1.04;
+  --guide-top-scale: -0.08;
+}
+
+.guide-letter--lowercase-descender {
+  --guide-font-scale: 1.04;
+  --guide-top-scale: -0.02;
+}
+
+.guide-letter--lowercase-word {
+  --guide-font-scale: 1.02;
+  --guide-top-scale: -0.05;
 }
 
 .baseline--top {


### PR DESCRIPTION
## Summary

アルファベットなぞり書きで、小文字や例示単語の薄字ガイドが手書き練習用の4本線に対してやや合っていなかったため、実表示を Playwright で確認しながら小文字・単語・罫線高さ別に調整しました。

## Related Issue

Relates to #31

先行PR後の表示確認で見つかった、なぞり書き小文字の位置・サイズ調整のフォローアップです。

## Changes Made

- なぞり書きガイドに文字種別のクラスを付与し、小文字の短字・上伸び字・下伸び字・小文字単語・先頭大文字単語でフォントサイズと上下位置を調整しました。
- 罫線高さ `8mm / 10mm / 12mm` に合わせて、なぞり書きの1ページあたり文字数と横方向の繰り返し数を再計算するようにしました。
- 罫線高さ変更後に不要な空ページが残らないよう、アルファベット練習時の `pageCount` を必要ページ数に同期するよう変更しました。
- `LayoutValidator` の二重読み込みを解消し、Playwright 実行時の `pageerror` をなくしました。

## Test Results

- `npm run typecheck` 成功
- `npm run lint` 成功（既存 warning のみ）
- `npm run test:content` 成功
- `npm run test:layout` 成功
- `npm run test -- --run` 成功
- `npm run build` 成功
- `npx prettier --check index.html script.js styles.css` 成功
- pre-commit フックで `test:content` / `test:layout` / `vitest --reporter=verbose` 成功

## Review Focus

Important review points:

- 小文字 `a/b` と単語 `apple/ant/ball/bear` の4本線上での位置が自然か
- `12mm` 時のページ数増加を、印刷時のA4収まり優先として許容できるか
- `LayoutValidator` の読み込み整理が既存の品質検証導線に影響していないか

## Breaking Changes

なし。

## Checklist

- [x] Playwright で `uppercase/lowercase` × `8mm/10mm/12mm` の実表示を撮影
- [x] 縦方向のはみ出しなしを確認
- [x] 横方向のはみ出しなしを確認
- [x] 空ページなしを確認
- [x] `12mm` ではA4収まりを優先し、1文字分/ページになることを確認

代表スクリーンショットはローカルの `test-results/lowercase-10mm-first-page-after.png`、`test-results/uppercase-12mm-first-page-after.png`、`test-results/lowercase-12mm-first-page-after.png` に生成しています。
