### PR TITLE
fix(alphabet): refine lowercase tracing baseline position

### DIFF
--- a/script.js
+++ b/script.js
@@ -1926,7 +1926,7 @@ function generateAlphabetPractice(pageNumber) {
     if (isTrace) {
       // なぞり書き: 文字 + 例示単語ごとに薄字ガイド付きベースラインを repeat 本描画
       bodyHtml += `<div class="alphabet-trace-row">
-                <div class="alphabet-trace-label">${escapeHtml(item.letter)}</div>
+                <div class="alphabet-trace-label"><span class="alphabet-trace-letter">${escapeHtml(item.letter)}</span></div>
                 <div class="alphabet-trace-lines">${repeatBaselineGroup(item.letter, traceRepeat, lineHeight)}</div>
             </div>`;
       if (showExample) {

--- a/styles.css
+++ b/styles.css
@@ -471,6 +471,7 @@ body::before {
 .guide-letter {
   --guide-font-scale: 1.08;
   --guide-top-scale: -0.15;
+  --guide-slant-correction: -4deg;
 
   position: absolute;
   left: 3mm;
@@ -496,6 +497,8 @@ body::before {
 
 .guide-letter > span {
   flex: 0 0 auto;
+  transform: skewX(var(--guide-slant-correction));
+  transform-origin: center 70%;
 }
 
 .guide-letter--mixed-word {
@@ -1298,12 +1301,20 @@ body::before {
 .alphabet-trace-label {
   font-family: var(--font-handwriting);
   font-size: 18pt;
+  font-style: normal;
   font-weight: 700;
   color: var(--primary-color);
   display: flex;
   flex-direction: column;
   gap: 1mm;
   padding-top: 1mm;
+}
+
+.alphabet-trace-letter,
+.alphabet-trace-label .example-word {
+  display: inline-block;
+  transform: skewX(-4deg);
+  transform-origin: center 70%;
 }
 
 .alphabet-trace-label .example-word {

--- a/styles.css
+++ b/styles.css
@@ -505,22 +505,22 @@ body::before {
 
 .guide-letter--lowercase-short {
   --guide-font-scale: 1;
-  --guide-top-scale: -0.03;
+  --guide-top-scale: -0.11;
 }
 
 .guide-letter--lowercase-ascender {
   --guide-font-scale: 1.04;
-  --guide-top-scale: -0.08;
+  --guide-top-scale: -0.13;
 }
 
 .guide-letter--lowercase-descender {
   --guide-font-scale: 1.04;
-  --guide-top-scale: -0.02;
+  --guide-top-scale: -0.04;
 }
 
 .guide-letter--lowercase-word {
   --guide-font-scale: 1.02;
-  --guide-top-scale: -0.05;
+  --guide-top-scale: -0.1;
 }
 
 .baseline--top {

--- a/styles.css
+++ b/styles.css
@@ -513,17 +513,17 @@ body::before {
 
 .guide-letter--lowercase-ascender {
   --guide-font-scale: 1.04;
-  --guide-top-scale: -0.13;
+  --guide-top-scale: -0.14;
 }
 
 .guide-letter--lowercase-descender {
   --guide-font-scale: 1.04;
-  --guide-top-scale: -0.04;
+  --guide-top-scale: -0.14;
 }
 
 .guide-letter--lowercase-word {
   --guide-font-scale: 1.02;
-  --guide-top-scale: -0.1;
+  --guide-top-scale: -0.13;
 }
 
 .baseline--top {


### PR DESCRIPTION
## Summary

公開後のスクリーンショット確認で、小文字なぞり書きの形は改善されている一方、`a/apple/ant/b` の薄字ガイドが4本線の基準線に対して少し低く、さらにフォント字形由来の右傾きも少し目立っていました。罫線高さやページ密度は変えず、小文字系ガイドの縦位置と、なぞり文字・英字ラベルの傾きを微調整します。

## Related Issue

Relates to #32

## Changes Made

- `guide-letter--lowercase-short` を上方向へ調整し、`a` の下端が太い基準線に近づくようにしました。
- `guide-letter--lowercase-word` を上方向へ調整し、`apple` / `ant` などの単語が基準線上に乗る見え方へ寄せました。
- `guide-letter--lowercase-ascender` を少し上げ、`b` の上伸びと基準線位置のバランスを改善しました。
- `guide-letter--lowercase-descender` は下伸び文字の余地を残しつつ、軽く上方向へ調整しました。
- なぞり用の薄字ガイドと英字ラベルに軽い逆方向の slant correction をかけ、手本として右に傾きすぎないようにしました。

## Test Results

- Playwright で `lowercase/uppercase` × `8mm/10mm/12mm` を撮影
- Playwright で pageerror なし、縦方向のはみ出しなし、横方向のはみ出しなしを確認
- `npm run typecheck` 成功
- `npm run lint` 成功（既存 warning のみ）
- `npm run test:content` 成功
- `npm run test:layout` 成功
- `npm run test -- --run` 成功
- `npm run build` 成功
- `npx prettier --check script.js styles.css` 成功
- pre-commit フックで `test:content` / `test:layout` / `vitest --reporter=verbose` 成功

## Review Focus

Important review points:

- 小文字 `a` の下端が太い基準線に自然に乗って見えるか
- `apple` / `ant` / `ball` / `bear` が低すぎず、かつ上がりすぎていないか
- なぞり文字と左側の英字ラベルの右傾きが弱まり、手本として自然に見えるか
- 日本語ラベルに傾き補正がかかっていないこと

## Breaking Changes

なし。

## Checklist

- [x] 罫線高さそのものは変更していない
- [x] 小文字系ガイドの縦位置を調整
- [x] なぞり用ガイドと英字ラベルの傾きを補正
- [x] 8/10/12mm の各表示を Playwright で確認
- [x] A4内の縦横はみ出しなしを確認
