### PR TITLE
fix(phrase): フレーズコレクションの本番環境ランタイム読み込み修正 (#37)

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,7 +64,7 @@ const modulesReady = (async () => {
   EXAMPLE_SENTENCES_BY_AGE = exampleModule.EXAMPLE_SENTENCES_BY_AGE;
   WORD_LISTS = wordModule.WORD_LISTS;
   ALPHABET_DATA = alphabetModule.ALPHABET_DATA;
-  PHRASE_DATA = phraseCollectionsModule.mergePhraseCollections(phraseModule.PHRASE_DATA);
+  PHRASE_DATA = await phraseCollectionsModule.loadMergedPhraseData(phraseModule.PHRASE_DATA);
   SIGHT_WORDS_DATA = sightWordsModule.SIGHT_WORDS;
   SIGHT_WORD_SET_DATA = sightWordsModule.SIGHT_WORD_SET;
   SIGHT_WORD_MAP_DATA = sightWordsModule.SIGHT_WORD_MAP;

--- a/src/data/phrase-collections.js
+++ b/src/data/phrase-collections.js
@@ -1,23 +1,22 @@
 /**
  * フレーズコレクション統合モジュール
  *
- * src/data/collections/phrases/*.json（全カテゴリー）を Vite の import.meta.glob で
- * 取り込み、phrase-data.js 由来の PHRASE_DATA とマージする。
+ * src/data/collections/phrases/*.json（全カテゴリー）を取り込み、phrase-data.js 由来の
+ * PHRASE_DATA とマージする。
+ *
+ * 取り込み経路は 2 系統：
+ *   1. Vite(dev / build) 経由なら import.meta.glob で静的展開（同期・ネットワーク不要）。
+ *   2. Vite を介さない素の静的配信（本番 GitHub Pages の生ソース配信 / live-server /
+ *      Playwright の webServer 等）では import.meta.glob が未変換のままブラウザに渡るため
+ *      関数として存在せず、呼び出しが TypeError になる。この場合は _manifest.json を起点に
+ *      各 JSON を fetch() で読み込むフォールバックへ切り替える。
  *
  * NOTE: import.meta は ES モジュール専用のため、CommonJS として構文チェックされる
- * script.js には置けない（CI の `node -c script.js` が失敗する）。そのため
- * import.meta.glob を使う処理はこのモジュールに分離し、script.js からは動的 import で
- * 読み込む。実行は Vite（dev / build）前提。
+ * script.js には置けない（CI の `node -c script.js` が失敗する）。そのため import.meta を
+ * 使う処理はこのモジュールに分離し、script.js からは動的 import で読み込む。
  */
 
 // _manifest.json も含めて取り込まれるが、items を持たないためマージ時に無視される。
-//
-// import.meta.glob は Vite 専用のビルド時マクロ。Vite(dev / build / 本番GitHub Pages)では
-// 全コレクションJSONに静的展開される。一方、Vite を介さずに配信された場合
-// (例: live-server / 素の静的サーバー / PlaywrightのwebServer) では import.meta.glob が
-// 関数として存在せず呼び出しが TypeError になり、データ読み込みチェーン全体が落ちてしまう。
-// その状況でもアプリがクラッシュしないよう try/catch でガードし、フォールバックとして
-// phrase-data.js の base データのみで動作させる。
 let COLLECTION_PHRASE_MODULES = {};
 try {
   COLLECTION_PHRASE_MODULES = import.meta.glob('./collections/phrases/*.json', {
@@ -25,6 +24,74 @@ try {
   });
 } catch (_e) {
   COLLECTION_PHRASE_MODULES = {};
+}
+
+const COLLECTIONS_DIR = './collections/phrases';
+
+/**
+ * _manifest.json を起点に各コレクション JSON を fetch して、
+ * import.meta.glob と同じ形（{ [path]: { default: data } }）のモジュールマップを返す。
+ * Vite を介さない素の静的配信時のフォールバック専用。
+ * import.meta.url を基準に URL を解決するため、GitHub Pages のサブパス配信でも正しく辿れる。
+ *
+ * @returns {Promise<Record<string, { default: any }>>}
+ */
+async function fetchPhraseModules() {
+  const modules = {};
+
+  if (typeof fetch !== 'function' || typeof import.meta?.url !== 'string') {
+    return modules;
+  }
+
+  let manifest;
+  try {
+    const manifestUrl = new URL(`${COLLECTIONS_DIR}/_manifest.json`, import.meta.url);
+    const res = await fetch(manifestUrl);
+    if (!res.ok) {
+      return modules;
+    }
+    manifest = await res.json();
+  } catch (_e) {
+    return modules;
+  }
+
+  const files = Array.isArray(manifest && manifest.files) ? manifest.files : [];
+
+  await Promise.all(
+    files.map(async (entry) => {
+      const name = entry && entry.name;
+      if (!name) {
+        return;
+      }
+      const relPath = `${COLLECTIONS_DIR}/${name}.json`;
+      try {
+        const res = await fetch(new URL(relPath, import.meta.url));
+        if (!res.ok) {
+          return;
+        }
+        modules[relPath] = { default: await res.json() };
+      } catch (_e) {
+        // 個別ファイルの失敗は握りつぶし、読めたものだけマージする。
+      }
+    })
+  );
+
+  return modules;
+}
+
+/**
+ * base（phrase-data.js）にコレクション JSON をマージした PHRASE_DATA を返す。
+ * import.meta.glob が機能していればそれを使い、空（= 素の静的配信）なら fetch で補完する。
+ *
+ * @param {Record<string, Record<string, Array>>} base
+ * @returns {Promise<Record<string, Record<string, Array>>>}
+ */
+export async function loadMergedPhraseData(base) {
+  let modules = COLLECTION_PHRASE_MODULES;
+  if (!modules || Object.keys(modules).length === 0) {
+    modules = await fetchPhraseModules();
+  }
+  return mergePhraseCollections(base, modules);
 }
 
 /**

--- a/src/data/phrase-collections.js
+++ b/src/data/phrase-collections.js
@@ -87,11 +87,12 @@ async function fetchPhraseModules() {
  * @returns {Promise<Record<string, Record<string, Array>>>}
  */
 export async function loadMergedPhraseData(base) {
-  let modules = COLLECTION_PHRASE_MODULES;
-  if (!modules || Object.keys(modules).length === 0) {
-    modules = await fetchPhraseModules();
+  // fetch フォールバックの結果はモジュールスコープにキャッシュし、
+  // 複数回呼ばれてもマニフェスト/各JSONへの再フェッチが起きないようにする。
+  if (!COLLECTION_PHRASE_MODULES || Object.keys(COLLECTION_PHRASE_MODULES).length === 0) {
+    COLLECTION_PHRASE_MODULES = await fetchPhraseModules();
   }
-  return mergePhraseCollections(base, modules);
+  return mergePhraseCollections(base, COLLECTION_PHRASE_MODULES);
 }
 
 /**


### PR DESCRIPTION
## 概要

本番 GitHub Pages において、フレーズ／クローズカテゴリーを選択すると無関係なコンテンツが出題されていたバグを修正しました。根本原因は `import.meta.glob`（Vite コンパイル時マクロ）が未変換のままブラウザに渡ることで、全コレクション JSON（21カテゴリー・約1514フレーズ）が読み込まれていなかった点です。`fetch()` によるランタイムフォールバックを追加し、Vite を介さない素の静的配信環境でも正しく動作するよう対応しました。

## 関連 Issue

このPRは単独のバグ修正です。

## 根本原因

デプロイワークフロー `.github/workflows/static.yml` は `vite build` を実行せずリポジトリをそのまま GitHub Pages に配信（`path: '.'`）します。そのため `src/data/phrase-collections.js` 内の `import.meta.glob(...)` がブラウザに未変換で届き、`TypeError` をスローします。これは `try/catch` で捕捉されていたため、`COLLECTION_PHRASE_MODULES` が空のオブジェクト `{}` になり、コレクション JSON が一切読み込まれませんでした。

結果として `getPhrasePool()` はコレクション専用の9カテゴリー（apologizing_thanking, health_body, hobbies, food_eating, weather, asking_for_help, opinions_preferences, making_plans, family）を `phrase-data.js` の base データ（12カテゴリー）に見つけられず、`['greetings']` フォールバックへ無音で切り替えていました。「謝る・感謝する」を選んでも "Have a safe trip!" のような greetings フレーズが出題されていた原因はこれです。phrase モードと cloze モードは `getPhrasePool` を共有しているため、両方が影響を受けていました。

## 変更内容

### 追加

- `src/data/phrase-collections.js` — `fetchPhraseModules()` 非同期関数：`_manifest.json` を起点に各カテゴリー JSON を `fetch()` で読み込み、`import.meta.glob` と同じ形式（`{ [path]: { default: data } }`）のモジュールマップを返す。`import.meta.url` を基準に URL 解決するため GitHub Pages のサブパス配信でも正しく動作する
- `src/data/phrase-collections.js` — `loadMergedPhraseData(base)` エクスポート関数：`COLLECTION_PHRASE_MODULES` が空であれば `fetchPhraseModules()` にフォールバックし、マージ済み `PHRASE_DATA` を非同期で返す

### 変更

- `script.js` — `mergePhraseCollections(...)` 呼び出し（同期）を `await loadMergedPhraseData(...)` に変更

### 読み込み経路の整理

| 環境 | 経路 |
|------|------|
| Vite dev / build | `import.meta.glob` による静的展開（従来どおり・変更なし） |
| 本番 GitHub Pages（生ソース配信） | `fetch()` フォールバック（今回追加） |
| live-server / Playwright webServer | `fetch()` フォールバック（今回追加） |

## テスト結果

- ユニットテスト: 124 / 124 件パス
- コンテンツテスト: 63 / 63 件パス
- レイアウトテスト: 26 / 26 件パス
- ESLint: エラー 0 件
- 実ブラウザ（live-server / 生静的配信相当）: コンソールエラーなし、「謝る・感謝する」で正しい謝罪フレーズが表示されること・greetings の混入がないことを確認。全21カテゴリーが読み込まれていることを確認

※ e2e スイートはポート 3000 を別プロセス（next-server）が占有していたため実行不可（本変更とは無関係）

## レビューフォーカス

### 重要

- `src/data/phrase-collections.js` — `fetchPhraseModules()` のフォールバックパス全体
  - `import.meta.url` を基準にした URL 解決ロジック（`new URL(relPath, import.meta.url)`）が GitHub Pages サブパス配信で正しく機能するか
  - `_manifest.json` の取得失敗・個別 JSON の取得失敗それぞれのエラーハンドリング
  - `Promise.all` で並列フェッチしていること（順次待ちを避けている点）

### 通常

- `src/data/phrase-collections.js` — `loadMergedPhraseData(base)` のロジック（`COLLECTION_PHRASE_MODULES` が空かどうかの判定）
- `script.js` — `mergePhraseCollections()` から `await loadMergedPhraseData()` への変更（同期→非同期の変更が呼び出し元で正しく `await` されているか）

## 確認手順

1. このブランチをチェックアウト: `git checkout fix/phrase-collections-runtime-load`
2. ライブサーバーで起動（Vite なし）: `npx live-server . --port=4000`
3. ブラウザで `http://localhost:4000` を開きコンソールを確認（エラーなし）
4. 「フレーズ練習」または「クローズテスト」を選択
5. カテゴリー「謝る・感謝する」（apologizing_thanking）を選択
6. 出題内容が謝罪・感謝フレーズであること、greetings が混入しないことを確認
7. `npm test` で全テストがパスすることを確認

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>